### PR TITLE
 Feat: step2 페이지 구현 

### DIFF
--- a/src/components/forms/pay/PayMethodForm.jsx
+++ b/src/components/forms/pay/PayMethodForm.jsx
@@ -15,7 +15,6 @@ const PayMethodForm = ({ handleChange, isSelected }) => {
   //level에 따라 animation 설정
   const level = useAtomValue(levelAtom);
 
-
   return (
     <FormWrap>
       {textArr.map((methodItem, index) => (

--- a/src/components/seatChart/SeatChart.jsx
+++ b/src/components/seatChart/SeatChart.jsx
@@ -9,8 +9,8 @@ const SeatChartContainer = styled.div`
   align-items: center;
   margin-top: 20px;
   //임시로 크기 지정, contentsBox배치 시 달라질 수 있음
-  width: 700px;
-  height: 400px;
+  width: 500px;
+  height: 500px;
 `;
 const Stage = styled.div`
   display: flex;

--- a/src/components/seatChart/seatGrid/Seat.jsx
+++ b/src/components/seatChart/seatGrid/Seat.jsx
@@ -19,6 +19,8 @@ const Seat = ({ isallowed }) => {
   const handleClick = () => {
     if (isallowed && !isSeatSelected) {
       setIsSeatSelected(true);
+    } else {
+      alert("이미 선택된 좌석입니다.");
     }
   };
   let focus = false;

--- a/src/components/seatInfo/SeatInfo.jsx
+++ b/src/components/seatInfo/SeatInfo.jsx
@@ -18,7 +18,7 @@ import {
   SeatPrice,
   ButtonAnimationArea
 } from "./SeatInfoStyles";
-
+import { useNavigate } from "react-router-dom";
 const SeatInfo = () => {
   const isSeatSelected = useAtomValue(isSeatSelectedAtom);
   const allowedSeat = useAtomValue(allowedSeatAtom);
@@ -30,7 +30,7 @@ const SeatInfo = () => {
     { grade: "3구역 0석", price: 49900 },
     { grade: "4구역 0석", price: 49900 }
   ];
-
+  const nav = useNavigate();
   //allowedSection이 유효한지 확인, 유효하다면 해당 구역의 좌석을 1석으로 변경
   if (allowedSection > 0 && allowedSection <= seats.length) {
     seats[allowedSection - 1].grade = `${allowedSection}구역 1석`;
@@ -40,6 +40,11 @@ const SeatInfo = () => {
   if (isSeatSelected && level == "low") {
     isFocus = true;
   }
+  const handleButtonClick = () => {
+    if (isSeatSelected) {
+      nav("/progress/step3");
+    }
+  };
   return (
     <SeatInfoContainer>
       <Header>좌석등급 / 잔여석</Header>
@@ -74,7 +79,11 @@ const SeatInfo = () => {
         </SelectedSeatsInfo>
       </SelectedSeats>
       <ButtonAnimationArea $focus={isFocus}>
-        <Button text={"좌석선택완료"} type={"select-seat"}></Button>
+        <Button
+          text={"좌석선택완료"}
+          type={"select-seat"}
+          onClick={handleButtonClick}
+        ></Button>
       </ButtonAnimationArea>
     </SeatInfoContainer>
   );

--- a/src/components/seatInfo/SeatInfo.jsx
+++ b/src/components/seatInfo/SeatInfo.jsx
@@ -43,6 +43,8 @@ const SeatInfo = () => {
   const handleButtonClick = () => {
     if (isSeatSelected) {
       nav("/progress/step3");
+    } else {
+      alert("좌석을 선택해주세요.");
     }
   };
   return (

--- a/src/components/seatSection/section/Section.jsx
+++ b/src/components/seatSection/section/Section.jsx
@@ -26,6 +26,8 @@ const Section = ({ num }) => {
   const handleSectionClick = () => {
     if (num == allowedSection) {
       setIsSectionSelected(true);
+    } else {
+      alert("알맞은 구역을 선택해주세요.");
     }
   };
   return (

--- a/src/components/seatSection/section/Section.jsx
+++ b/src/components/seatSection/section/Section.jsx
@@ -1,7 +1,11 @@
 import styled from "styled-components";
 import AnimationArea from "../../Animation";
-import { useAtomValue } from "jotai";
-import { allowedSectionAtom, levelAtom } from "../../../store/atom";
+import { useAtomValue, useSetAtom } from "jotai";
+import {
+  allowedSectionAtom,
+  levelAtom,
+  isSectionSelectedAtom
+} from "../../../store/atom";
 
 const SectionDiv = styled.div`
   border: 1px solid var(--key-color);
@@ -13,14 +17,22 @@ const SectionDiv = styled.div`
 `;
 const Section = ({ num }) => {
   const allowedSection = useAtomValue(allowedSectionAtom);
+  const setIsSectionSelected = useSetAtom(isSectionSelectedAtom);
   const level = useAtomValue(levelAtom);
   let isfocus = false;
   if (num == allowedSection && level == "low") {
     isfocus = true;
   }
+  const handleSectionClick = () => {
+    if (num == allowedSection) {
+      setIsSectionSelected(true);
+    }
+  };
   return (
     <AnimationArea $focus={isfocus}>
-      <SectionDiv $cursor={isfocus}>{num}구역</SectionDiv>
+      <SectionDiv $cursor={isfocus} onClick={handleSectionClick}>
+        {num}구역
+      </SectionDiv>
     </AnimationArea>
   );
 };

--- a/src/pages/practiceMode/step2/SelectSeat.jsx
+++ b/src/pages/practiceMode/step2/SelectSeat.jsx
@@ -1,15 +1,23 @@
 import SeatSection from "../../../components/seatSection/SeatSection";
 import SeatInfo from "../../../components/seatInfo/SeatInfo";
+import SeatChart from "../../../components/seatChart/SeatChart";
 import styled from "styled-components";
+import { useAtomValue } from "jotai";
+import { isSectionSelectedAtom } from "../../../store/atom";
 const SelectSeatcontainer = styled.div`
   display: flex;
   justify-content: space-evenly;
   align-items: center;
 `;
 const SelectSeat = () => {
+  const isSectionSelected = useAtomValue(isSectionSelectedAtom);
   return (
     <SelectSeatcontainer>
-      <SeatSection></SeatSection>
+      {isSectionSelected ? (
+        <SeatChart></SeatChart>
+      ) : (
+        <SeatSection></SeatSection>
+      )}
       <SeatInfo></SeatInfo>
     </SelectSeatcontainer>
   );

--- a/src/pages/practiceMode/step2/SelectSeat.jsx
+++ b/src/pages/practiceMode/step2/SelectSeat.jsx
@@ -1,5 +1,18 @@
+import SeatSection from "../../../components/seatSection/SeatSection";
+import SeatInfo from "../../../components/seatInfo/SeatInfo";
+import styled from "styled-components";
+const SelectSeatcontainer = styled.div`
+  display: flex;
+  justify-content: space-evenly;
+  align-items: center;
+`;
 const SelectSeat = () => {
-  return <></>;
+  return (
+    <SelectSeatcontainer>
+      <SeatSection></SeatSection>
+      <SeatInfo></SeatInfo>
+    </SelectSeatcontainer>
+  );
 };
 
 export default SelectSeat;

--- a/src/pages/practiceMode/step2/SelectSeat.jsx
+++ b/src/pages/practiceMode/step2/SelectSeat.jsx
@@ -1,0 +1,5 @@
+const SelectSeat = () => {
+  return <></>;
+};
+
+export default SelectSeat;

--- a/src/routes.jsx
+++ b/src/routes.jsx
@@ -10,6 +10,7 @@ import SelectRound from "./pages/practiceMode/step1/SelectRound";
 import SelectPayMethod from "./pages/practiceMode/step4/SelectPayMethod";
 import CardPay from "./pages/practiceMode/step4/CardPay";
 import Step5 from "./pages/practiceMode/step5/Step5";
+import SelectSeat from "./pages/practiceMode/step2/SelectSeat";
 
 const router = createBrowserRouter([
   {
@@ -37,6 +38,7 @@ const router = createBrowserRouter([
             element: <SelectRound />,
             label: "날짜 및 회차 선택"
           },
+          { path: "step2", element: <SelectSeat />, label: "좌석 선택" },
           {
             path: "step4-1",
             element: <SelectPayMethod />,

--- a/src/store/atom.js
+++ b/src/store/atom.js
@@ -42,9 +42,12 @@ export const allowedSeatAtom = atom({
 //좌석 선택 여부 상태
 export const isSeatSelectedAtom = atom(false);
 
+export const isSectionSelectedAtom = atom(false);
+
 //구역 선택
 export const allowedSectionAtom = atom(getRandomInt(1, 4));
 
+//사용자 이름
 export const userNameAtom = atom("");
 
 //연습모드 완료 횟수

--- a/src/store/atom.js
+++ b/src/store/atom.js
@@ -42,6 +42,7 @@ export const allowedSeatAtom = atom({
 //좌석 선택 여부 상태
 export const isSeatSelectedAtom = atom(false);
 
+//구역 선택 여부 상태
 export const isSectionSelectedAtom = atom(false);
 
 //구역 선택


### PR DESCRIPTION
# 📝작업 내용
-정해진 구역이 선택되었는지 나타내는 Atom 추가(isSectionSelected)
-알맞은 구역 선택시 구역컴포넌트가 좌석선택 컴포넌트로 바뀜
-보라색 좌석을 클릭하고 좌석선택완료 버튼을 누르면  step3 페이지로 넘어감
-중간에 잘못된 영역을 선택시 alret창이 나타남

-SeatInfo 컴포넌트가 같은곳에 공통으로 들어가서 단계별로 새 rout를 주소를 만들지 않고
 좌석 선택 여부 Atom과 삼항연산자를 이용해 컴포넌트 렌더링함
-나중에 멘트 불러올때도  같은 방법으로 각각 불러오면 될 것 같습니다

## 스크린샷 (선택)
![image](https://github.com/user-attachments/assets/5392abac-9f63-422e-a1e2-4f7900361053)
![image](https://github.com/user-attachments/assets/ac8904e9-2306-4507-a8c5-35ac8b8f7451)


## 💬리뷰 요구사항
