### PR TITLE
Feat: My예매정보 컴포넌트 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,5 @@ dist-ssr
 *.njsproj
 *.sln
 *.sw?
+
+.eslintcache

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -2,7 +2,6 @@
 import React from "react";
 import { RouterProvider } from "react-router-dom";
 import router from "./routes";
-import MyBookingInfo from "./components/myBookingInfo/MyBookinfInfo";
 
 function App() {
   return <RouterProvider router={router} />;

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -2,6 +2,7 @@
 import React from "react";
 import { RouterProvider } from "react-router-dom";
 import router from "./routes";
+import MyBookingInfo from "./components/myBookingInfo/MyBookinfInfo";
 
 function App() {
   return <RouterProvider router={router} />;

--- a/src/components/button/Button.module.css
+++ b/src/components/button/Button.module.css
@@ -1,4 +1,4 @@
-/* 디폴트(이전, 다음 단계) */
+/* 디폴트(다음 단계) */
 .button {
   display: flex;
   width: 180px;
@@ -21,6 +21,17 @@
   transition: 0.8s ease;
 }
 
+/*이전 단계*/
+.button--prev {
+  background-color: var(--sub-color);
+  border: 1px solid var(--key-color);
+  color: var(--key-color);
+}
+.button--prev:hover {
+  background-color: var(--sub-color);
+  border: 1px solid var(--key-color);
+  color: var(--key-color);
+}
 /* 좌석 선택 */
 .button--select-seat {
   width: 285px;

--- a/src/components/forms/pay/PayMethodForm.jsx
+++ b/src/components/forms/pay/PayMethodForm.jsx
@@ -15,7 +15,6 @@ const PayMethodForm = ({ handleChange, isSelected }) => {
   //level에 따라 animation 설정
   const level = useAtomValue(levelAtom);
 
-
   return (
     <FormWrap>
       {textArr.map((methodItem, index) => (

--- a/src/components/myBookingInfo/MyBookinfInfo.jsx
+++ b/src/components/myBookingInfo/MyBookinfInfo.jsx
@@ -1,7 +1,7 @@
 import styled from "styled-components";
 import Button from "../button/Button";
 import Animation from "../Animation";
-import { allowedSeatAtom } from "../../store/atom";
+import { allowedSeatAtom, isDeliverySelectedAtom } from "../../store/atom";
 import { useAtomValue } from "jotai";
 import { useNavigate } from "react-router-dom";
 
@@ -63,6 +63,7 @@ const NextAnimation = styled(Animation)`
 `;
 const MyBookingInfo = () => {
   const allowedSeat = useAtomValue(allowedSeatAtom);
+  const delivery = useAtomValue(isDeliverySelectedAtom);
   const Info = [
     // 공연 날짜 Atom 필요
     { title: "일시", content: "2024년 6월 29일(토) 14:00" },
@@ -72,12 +73,12 @@ const MyBookingInfo = () => {
     },
     { title: "티켓금액", content: "99000원" },
     { title: "수수료", content: "2000원" },
-    { title: "쿠폰할인", content: "0원" },
-    { title: "포인트할인", content: "0원" }
+    { title: "배송비", content: delivery ? "3000원" : "0원" },
+    { title: "쿠폰할인", content: "0원" }
   ];
-  const nav = useNavigate();
+  // const nav = useNavigate();
   const handleButtonClick = () => {
-    nav("/progress/step4-1");
+    // nav("/progress/step4-1");
   };
 
   return (
@@ -93,7 +94,7 @@ const MyBookingInfo = () => {
       </InfoContatiner>
       <TotalAmount>
         <AmountTitle>총 결제금액</AmountTitle>
-        <AmountContent>101000원</AmountContent>
+        <AmountContent>{delivery ? "104000원" : "101000원"}</AmountContent>
       </TotalAmount>
       <ButtonContainer>
         <PaddingContainer>

--- a/src/components/myBookingInfo/MyBookinfInfo.jsx
+++ b/src/components/myBookingInfo/MyBookinfInfo.jsx
@@ -76,9 +76,9 @@ const MyBookingInfo = () => {
     { title: "배송비", content: delivery ? "3000원" : "0원" },
     { title: "쿠폰할인", content: "0원" }
   ];
-  // const nav = useNavigate();
+  const nav = useNavigate();
   const handleButtonClick = () => {
-    // nav("/progress/step4-1");
+    nav("/progress/step4-1");
   };
 
   return (

--- a/src/components/myBookingInfo/MyBookinfInfo.jsx
+++ b/src/components/myBookingInfo/MyBookinfInfo.jsx
@@ -1,0 +1,111 @@
+import styled from "styled-components";
+import Button from "../button/Button";
+import Animation from "../Animation";
+import { allowedSeatAtom } from "../../store/atom";
+import { useAtomValue } from "jotai";
+import { useNavigate } from "react-router-dom";
+
+const Container = styled.div`
+  border: 1px solid var(--key-color);
+  border-radius: 8px;
+  width: 400px;
+  height: 457px;
+  margin: 20px auto;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+`;
+
+const Title = styled.div`
+  font-family: pretendardB;
+  margin-bottom: 20px;
+  margin: 20px 20px 0 20px;
+`;
+
+const InfoContatiner = styled.div`
+  display: flex;
+  flex-direction: column;
+  margin: 20px 20px 0 20px;
+  font-family: pretendardR;
+`;
+const InfoItem = styled.div`
+  display: flex;
+  justify-content: space-between;
+  margin: 10px 0;
+`;
+const InfoText = styled.div``;
+const TotalAmount = styled.div`
+  margin: 0 20px 0 20px;
+  display: flex;
+  justify-content: space-between;
+  border-top: 1px solid var(--key-color);
+`;
+
+const AmountTitle = styled.div`
+  font-family: B;
+  margin-top: 20px;
+  font-family: pretendardB;
+`;
+const AmountContent = styled.div`
+  font-family: pretendardB;
+  font-size: 28px;
+  margin-top: 20px;
+`;
+const ButtonContainer = styled.div`
+  display: flex;
+  justify-content: space-around;
+`;
+const PaddingContainer = styled.div`
+  padding: 6px;
+`;
+const NextAnimation = styled(Animation)`
+  padding: 3px;
+`;
+const MyBookingInfo = () => {
+  const allowedSeat = useAtomValue(allowedSeatAtom);
+  const Info = [
+    // 공연 날짜 Atom 필요
+    { title: "일시", content: "2024년 6월 29일(토) 14:00" },
+    {
+      title: "선택좌석(1석)",
+      content: `${allowedSeat.row + 1}열-${allowedSeat.col + 1}`
+    },
+    { title: "티켓금액", content: "99000원" },
+    { title: "수수료", content: "2000원" },
+    { title: "쿠폰할인", content: "0원" },
+    { title: "포인트할인", content: "0원" }
+  ];
+  const nav = useNavigate();
+  const handleButtonClick = () => {
+    nav("/progress/step4-1");
+  };
+
+  return (
+    <Container>
+      <Title>My 예매 정보</Title>
+      <InfoContatiner>
+        {Info.map((item, index) => (
+          <InfoItem key={index}>
+            <InfoText>{item.title}</InfoText>
+            <InfoText>{item.content}</InfoText>
+          </InfoItem>
+        ))}
+      </InfoContatiner>
+      <TotalAmount>
+        <AmountTitle>총 결제금액</AmountTitle>
+        <AmountContent>101000원</AmountContent>
+      </TotalAmount>
+      <ButtonContainer>
+        <PaddingContainer>
+          <Button text="이전 단계" type="prev"></Button>
+        </PaddingContainer>
+
+        <NextAnimation $focus={true}>
+          <Button text="다음 단계" onClick={handleButtonClick}></Button>
+        </NextAnimation>
+      </ButtonContainer>
+    </Container>
+  );
+};
+
+export default MyBookingInfo;

--- a/src/store/atom.js
+++ b/src/store/atom.js
@@ -49,3 +49,6 @@ export const userNameAtom = atom("");
 
 //연습모드 완료 횟수
 export const practiceCountAtom = atomWithStorage("practiceCount", 0);
+
+//배송 선택 여부 상태
+export const isDeliverySelectedAtom = atom(false);


### PR DESCRIPTION
# 📝작업 내용

**추가한 것**
- isDeliverySelectedAtom : 배송 선택 여부를 나타내는 Atom
- Button.css에 prev type(이전 단계) 추가

**구현 방법**
- 좌석 매수 선택이나 배송 선택에 따라 총 결제금액이  달라지도록 구현
- 다음단계 버튼을 클릭시 버튼이 결제하기로 바뀜

**논의하고 싶은 것**
-지금은 공연 날짜가 고정되서 poster.json에  적혀있는데 캘린더 컴포넌트는 현재 월을 기준으로 달력을 보여줘서 선택하기가 애매해. 공연 날짜를 현재 월을 기준으로 변할 수 있게 하거나 캘린더를 공연 날짜의 달로 보여주기 중에 하나를 선택하고 싶은게 어떤게 좋을까?

## 스크린샷 (선택)
![image](https://github.com/user-attachments/assets/03732906-e32b-408e-be14-2a05d10a9211)
다음단계를 누르면 결제하기로 바뀜
![image](https://github.com/user-attachments/assets/09ebbc61-d43b-4d56-8ee5-3d069b8f7260)

## step3 만들때 참고사함
- 티켓 수령방법에서 배송을 선택시 isDeliverySelectedAtom이 true로 바뀌게 해주면 자동으로 가격이 반영되게 해놨습니다.
- **예매자 확인폼을 다른 컴포넌트에서 확인할 수 있는 방법이 아직 없음**
- 3-1 에서 3-2로 넘어갈때 버튼에 애니메이션이 계속 남아있음, 예매자 확인 폼에 애니메이션을 먼저 넣고 싶으면 추가 수정이 필요
- 예매자 확인 폼이 작성되지 않거나 정답이 틀린경우 alret을 띄우는 기능이 필요
- 지금은 step3-2에서 바로 결제하기 버튼을 누르면 step 4-1로 넘어감

## 💬리뷰 요구사항
