### PR TITLE
Feat: 티켓 매수 선택 컴포넌트 구현

### DIFF
--- a/src/components/SeatCount.jsx
+++ b/src/components/SeatCount.jsx
@@ -1,6 +1,7 @@
 import styled from "styled-components";
-import { seatCountAtom } from "../store/atom";
-import { useAtom } from "jotai";
+import { useEffect, useState } from "react";
+import { seatCountAtom, levelAtom } from "../store/atom";
+import { useAtom, useAtomValue } from "jotai";
 import Animation from "./Animation";
 const SeatCountContainer = styled.div`
   border: 1px solid var(--key-color);
@@ -47,14 +48,21 @@ const HighlightText = styled.span`
 
 const SeatCount = () => {
   const [seatCount, setSeatCount] = useAtom(seatCountAtom);
+  const level = useAtomValue(levelAtom);
+  const [focus, setFocus] = useState(false);
 
   const handleSeatCountChange = (event) => {
     setSeatCount(Number(event.target.value));
   };
-  let focus = true;
-  if (seatCount === 1) {
-    focus = false;
-  }
+
+  useEffect(() => {
+    if (seatCount === 0 && level === "low") {
+      setFocus(true);
+    } else if (seatCount === 1) {
+      setFocus(false);
+    }
+  }, [seatCount]);
+
   return (
     <SeatCountContainer>
       <Header>티켓 가격</Header>

--- a/src/components/SeatCount.jsx
+++ b/src/components/SeatCount.jsx
@@ -38,6 +38,7 @@ const CountSelector = styled.select`
   border-radius: 4px;
   text-align: center;
   font-size: 16px;
+  margin: ${(props) => (props.$focus ? "0px" : "3px")};
 `;
 
 const HighlightText = styled.span`
@@ -50,7 +51,10 @@ const SeatCount = () => {
   const handleSeatCountChange = (event) => {
     setSeatCount(Number(event.target.value));
   };
-
+  let focus = true;
+  if (seatCount === 1) {
+    focus = false;
+  }
   return (
     <SeatCountContainer>
       <Header>티켓 가격</Header>
@@ -62,8 +66,12 @@ const SeatCount = () => {
         <InfoText>기본가</InfoText>
         <InfoText>일반</InfoText>
         <InfoText>99,000원</InfoText>
-        <Animation $focus={true}>
-          <CountSelector name={"seatCount"} onChange={handleSeatCountChange}>
+        <Animation $focus={focus}>
+          <CountSelector
+            $focus={focus}
+            name={"seatCount"}
+            onChange={handleSeatCountChange}
+          >
             <option value={0}>0매</option>
             <option value={1}>1매</option>
           </CountSelector>

--- a/src/components/SeatCount.jsx
+++ b/src/components/SeatCount.jsx
@@ -1,0 +1,76 @@
+import styled from "styled-components";
+import { seatCountAtom } from "../store/atom";
+import { useAtom } from "jotai";
+import Animation from "./Animation";
+const SeatCountContainer = styled.div`
+  border: 1px solid var(--key-color);
+  border-radius: 8px;
+  padding: 20px;
+  padding-bottom: 10px;
+  width: 500px;
+  height: 140px;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+`;
+
+const Header = styled.div`
+  font-family: PretendardB;
+  font-size: 24px;
+`;
+
+const InfoRow = styled.div`
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-top: 10px;
+  font-family: PretendardR;
+`;
+
+const InfoText = styled.div`
+  color: var(--text-color);
+`;
+
+const CountSelector = styled.select`
+  width: 70px;
+  height: 30px;
+  border: 1px solid;
+  border-radius: 4px;
+  text-align: center;
+  font-size: 16px;
+`;
+
+const HighlightText = styled.span`
+  color: var(--point-color);
+`;
+
+const SeatCount = () => {
+  const [seatCount, setSeatCount] = useAtom(seatCountAtom);
+
+  const handleSeatCountChange = (event) => {
+    setSeatCount(Number(event.target.value));
+  };
+
+  return (
+    <SeatCountContainer>
+      <Header>티켓 가격</Header>
+      <Header>
+        스탠딩 | <HighlightText>좌석 {seatCount}매</HighlightText>를
+        선택하셨습니다
+      </Header>
+      <InfoRow>
+        <InfoText>기본가</InfoText>
+        <InfoText>일반</InfoText>
+        <InfoText>99,000원</InfoText>
+        <Animation $focus={true}>
+          <CountSelector name={"seatCount"} onChange={handleSeatCountChange}>
+            <option value={0}>0매</option>
+            <option value={1}>1매</option>
+          </CountSelector>
+        </Animation>
+      </InfoRow>
+    </SeatCountContainer>
+  );
+};
+
+export default SeatCount;

--- a/src/components/SeatCount.jsx
+++ b/src/components/SeatCount.jsx
@@ -1,8 +1,15 @@
 import styled from "styled-components";
 import { useEffect, useState } from "react";
-import { seatCountAtom, levelAtom } from "../store/atom";
+import {
+  seatCountAtom,
+  levelAtom,
+  postersAtom,
+  selectedPosterAtom,
+  seatInfoAtom
+} from "../store/atom";
 import { useAtom, useAtomValue } from "jotai";
 import Animation from "./Animation";
+
 const SeatCountContainer = styled.div`
   border: 1px solid var(--key-color);
   border-radius: 8px;
@@ -49,6 +56,7 @@ const HighlightText = styled.span`
 const SeatCount = () => {
   const [seatCount, setSeatCount] = useAtom(seatCountAtom);
   const level = useAtomValue(levelAtom);
+  const seatInfo = useAtomValue(seatInfoAtom);
   const [focus, setFocus] = useState(false);
 
   const handleSeatCountChange = (event) => {
@@ -67,13 +75,13 @@ const SeatCount = () => {
     <SeatCountContainer>
       <Header>티켓 가격</Header>
       <Header>
-        스탠딩 | <HighlightText>좌석 {seatCount}매</HighlightText>를
+        {seatInfo.grade} | <HighlightText>좌석 {seatCount}매</HighlightText>를
         선택하셨습니다
       </Header>
       <InfoRow>
         <InfoText>기본가</InfoText>
         <InfoText>일반</InfoText>
-        <InfoText>99,000원</InfoText>
+        <InfoText>{seatInfo.price}원</InfoText>
         <Animation $focus={focus}>
           <CountSelector
             $focus={focus}

--- a/src/components/seatChart/seatGrid/SeatGrid.jsx
+++ b/src/components/seatChart/seatGrid/SeatGrid.jsx
@@ -5,8 +5,8 @@ import { allowedSeatAtom } from "../../../store/atom.js";
 
 const GridContainer = styled.div`
   display: grid;
-  grid-template-rows: ${(props) => `repeat(${props.rows}, 25px)`};
-  grid-template-columns: ${(props) => `repeat(${props.columns}, 25px)`};
+  grid-template-rows: ${(props) => `repeat(${props.$rows}, 25px)`};
+  grid-template-columns: ${(props) => `repeat(${props.$columns}, 25px)`};
   place-items: center;
   padding: 0;
 `;
@@ -33,7 +33,7 @@ const SeatGrid = ({ rows = 5, columns = 5, gridIndex }) => {
   };
 
   return (
-    <GridContainer rows={rows} columns={columns}>
+    <GridContainer $rows={rows} $columns={columns}>
       {renderSeats()}
     </GridContainer>
   );

--- a/src/components/seatInfo/SeatInfo.jsx
+++ b/src/components/seatInfo/SeatInfo.jsx
@@ -1,10 +1,13 @@
 import Button from "../button/Button";
-import { useAtomValue } from "jotai";
+import { useAtomValue, useAtom } from "jotai";
 import {
   isSeatSelectedAtom,
   allowedSeatAtom,
   levelAtom,
-  allowedSectionAtom
+  allowedSectionAtom,
+  postersAtom,
+  selectedPosterAtom,
+  seatInfoAtom
 } from "../../store/atom";
 import {
   SeatInfoContainer,
@@ -18,23 +21,26 @@ import {
   SeatPrice,
   ButtonAnimationArea
 } from "./SeatInfoStyles";
+import convertPriceObjectToArray from "../../util/convertPriceObjectToArray";
+import getRandomSeat from "../../util/getRandomSeat";
+import { useEffect } from "react";
 
 const SeatInfo = () => {
   const isSeatSelected = useAtomValue(isSeatSelectedAtom);
   const allowedSeat = useAtomValue(allowedSeatAtom);
-  const allowedSection = useAtomValue(allowedSectionAtom);
   const level = useAtomValue(levelAtom);
-  const seats = [
-    { grade: "1구역 0석", price: 99000 },
-    { grade: "2구역 0석", price: 99000 },
-    { grade: "3구역 0석", price: 49900 },
-    { grade: "4구역 0석", price: 49900 }
-  ];
 
-  //allowedSection이 유효한지 확인, 유효하다면 해당 구역의 좌석을 1석으로 변경
-  if (allowedSection > 0 && allowedSection <= seats.length) {
-    seats[allowedSection - 1].grade = `${allowedSection}구역 1석`;
-  }
+  const posters = useAtomValue(postersAtom);
+  const posterId = useAtomValue(selectedPosterAtom);
+  const selectedPoster = posters[posterId];
+
+  const seats = convertPriceObjectToArray(selectedPoster.price);
+  const [seatInfo, setSeatInfo] = useAtom(seatInfoAtom);
+  useEffect(() => {
+    if (isSeatSelected) {
+      setSeatInfo(getRandomSeat(selectedPoster));
+    }
+  }, [isSeatSelected]);
 
   let isFocus = false;
   if (isSeatSelected && level == "low") {
@@ -67,7 +73,7 @@ const SeatInfo = () => {
           <SeatPrice>좌석정보</SeatPrice>
           {isSeatSelected && (
             <>
-              <SeatGrade>전석</SeatGrade>
+              <SeatGrade>{seatInfo.grade}</SeatGrade>
               <SeatPrice>{`${allowedSeat.row + 1}열-${allowedSeat.col + 1}`}</SeatPrice>
             </>
           )}

--- a/src/components/seatInfo/SeatInfoStyles.jsx
+++ b/src/components/seatInfo/SeatInfoStyles.jsx
@@ -30,7 +30,7 @@ export const SeatTableContainer = styled.div`
   height: 110px;
   display: flex;
   flex-direction: column;
-  justify-content: space-between;
+  // justify-content: space-between;
 `;
 
 export const SeatTableDiv = styled.div`

--- a/src/store/atom.js
+++ b/src/store/atom.js
@@ -49,3 +49,6 @@ export const userNameAtom = atom("");
 
 //연습모드 완료 횟수
 export const practiceCountAtom = atomWithStorage("practiceCount", 0);
+
+//좌석 매수 개수
+export const seatCountAtom = atom(0);

--- a/src/store/atom.js
+++ b/src/store/atom.js
@@ -52,3 +52,9 @@ export const practiceCountAtom = atomWithStorage("practiceCount", 0);
 
 //좌석 매수 개수
 export const seatCountAtom = atom(0);
+
+//좌석 등급, 가격
+export const seatInfoAtom = atom({
+  grade: "",
+  price: 0
+});

--- a/src/store/atom.js
+++ b/src/store/atom.js
@@ -56,5 +56,6 @@ export const seatCountAtom = atom(0);
 //좌석 등급, 가격
 export const seatInfoAtom = atom({
   grade: "",
-  price: 0
+  price: 0,
+  date: ""
 });

--- a/src/util/convertPriceObjectToArray.js
+++ b/src/util/convertPriceObjectToArray.js
@@ -1,0 +1,17 @@
+import convertPriceToNumber from "./convertPriceToNumber";
+
+// 객체를 배열로 변환
+function convertPriceObjectToArray(priceObj) {
+  const seats = [];
+
+  for (const [seatName, seatPrice] of Object.entries(priceObj)) {
+    seats.push({
+      grade: seatName,
+      price: convertPriceToNumber(seatPrice)
+    });
+  }
+
+  return seats;
+}
+
+export default convertPriceObjectToArray;

--- a/src/util/convertPriceToNumber.js
+++ b/src/util/convertPriceToNumber.js
@@ -1,0 +1,6 @@
+// 가격 문자열을 숫자로 변환
+function convertPriceToNumber(priceStr) {
+  return parseInt(priceStr.replace(/,/g, "").replace("원", ""), 10);
+}
+
+export default convertPriceToNumber;

--- a/src/util/getRandomSeat.js
+++ b/src/util/getRandomSeat.js
@@ -1,0 +1,14 @@
+import convertPriceToNumber from "./convertPriceToNumber";
+function getRandomSeat(poster) {
+  const seatNames = Object.keys(poster.price);
+
+  const randomIndex = Math.floor(Math.random() * seatNames.length);
+
+  const randomSeat = seatNames[randomIndex];
+
+  const randomPrice = convertPriceToNumber(poster.price[randomSeat]);
+
+  return { grade: randomSeat, price: randomPrice };
+}
+
+export default getRandomSeat;

--- a/src/util/getRandomSeat.js
+++ b/src/util/getRandomSeat.js
@@ -8,7 +8,7 @@ function getRandomSeat(poster) {
 
   const randomPrice = convertPriceToNumber(poster.price[randomSeat]);
 
-  return { grade: randomSeat, price: randomPrice };
+  return { grade: randomSeat, price: randomPrice, date: poster.date };
 }
 
 export default getRandomSeat;


### PR DESCRIPTION
# 📝작업 내용
**seatCountAtom** :티켓 매수를 나타내는 atom, 초기값 0

- 컴포넌트에 애니메이션이 들어간 부분에서 드롭다운으로 매수 선택가능 (최대 1매)
- 매수 선택시 애니메이션 사라짐 -> 내 예매정보 컴포넌트의 다음단계버튼에 애니메이션 들어옴

## 스크린샷 (선택)
![image](https://github.com/user-attachments/assets/fe2b5917-88fb-4e53-96ff-d9cbd333339e)

## 💬리뷰 요구사항

## 리팩토링

SeatInfo 컴포넌트에서 posterAtom에 있는 좌석 등급, 가격을 받아와 랜덤으로 선택, Atom에 등록

```
//좌석 등급, 가격을 나타내는 Atom
export const seatInfoAtom = atom({
  grade: "",
  price: 0,
  date:""
});
```

위 Atom 정보를 받아와 표시
![image](https://github.com/user-attachments/assets/9f86ef1a-a867-480d-88df-9d294efeb609)

