### PR TITLE
Refactor : 타이머 제어 및 추가 사항

### DIFF
--- a/src/components/forms/pay/DetailPayForm.jsx
+++ b/src/components/forms/pay/DetailPayForm.jsx
@@ -58,7 +58,7 @@ const DetailPayForm = ({ handleChange, isSelected, isAnswer }) => {
           />
         ))}
       </FormWrap>
-      <AnimationArea $focus={isSelected && !isAnswer}>
+      <AnimationArea $focus={level !== "high" && isSelected && !isAnswer}>
         <DropDown name="CardTypes" onChange={handleChange}>
           {/*드롭다운의 placeholder역할 */}
           <option value="" disabled>

--- a/src/components/forms/ticket/TicketMethod.jsx
+++ b/src/components/forms/ticket/TicketMethod.jsx
@@ -22,6 +22,7 @@ const TicketMethodWrap = styled(FormWrap)`
   justify-content: center;
   align-items: start;
   padding: 20px;
+  height: 417px;
 `;
 const TicketMethod = ({ option, setOption }) => {
   const handleOptionChange = (e) => {

--- a/src/pages/ProgressContents.jsx
+++ b/src/pages/ProgressContents.jsx
@@ -5,8 +5,8 @@ import { Outlet } from "react-router-dom";
 import Button from "../components/button/Button";
 import { useState } from "react";
 import Modal from "../components/Modal";
-import { useAtomValue } from "jotai";
-import { levelAtom } from "../store/atom";
+import { useAtomValue, useSetAtom } from "jotai";
+import { levelAtom, writeSecondCount } from "../store/atom";
 
 //ProgressBar+ContentsBox Container
 const ProgressContentsContainer = styled.div`
@@ -52,12 +52,14 @@ const ProgressContents = ({ text }) => {
   //레벨 별 타이머 출력 설정
   const level = useAtomValue(levelAtom);
   const [isModalOpen, setIsModalOpen] = useState(false);
+
   const handleModalOpen = () => {
     setIsModalOpen(true);
   };
   const handleModalClose = () => {
     setIsModalOpen(false);
   };
+
   return (
     <ProgressContentsContainer>
       {/*프로그래스 바*/}
@@ -65,7 +67,10 @@ const ProgressContents = ({ text }) => {
         <ProgressBar />
       </ProgressBarBox>
       {/*고급 level일 경우에만 Timer 설정 */}
-      {level === "high" && <Timer type={"minute"} second={1000} />}
+      {/*모달이 열렸을 경우 Timer 정지*/}
+      {level === "high" && (
+        <Timer type={"minute"} second={1000} isModalOpen={isModalOpen} />
+      )}
       <TextBox>{text}</TextBox>
       <ContentsBox>
         {/*도움말 버튼 */}

--- a/src/pages/ProgressContents.jsx
+++ b/src/pages/ProgressContents.jsx
@@ -5,6 +5,8 @@ import { Outlet } from "react-router-dom";
 import Button from "../components/button/Button";
 import { useState } from "react";
 import Modal from "../components/Modal";
+import { useAtomValue } from "jotai";
+import { levelAtom } from "../store/atom";
 
 //ProgressBar+ContentsBox Container
 const ProgressContentsContainer = styled.div`
@@ -47,6 +49,8 @@ const ButtonContainer = styled.div`
 /*난이도별 contents를 children으로 받아서 ProgressBar와 함께 렌더링
 Outlet으로 대체 예정*/
 const ProgressContents = ({ text }) => {
+  //레벨 별 타이머 출력 설정
+  const level = useAtomValue(levelAtom);
   const [isModalOpen, setIsModalOpen] = useState(false);
   const handleModalOpen = () => {
     setIsModalOpen(true);
@@ -60,7 +64,8 @@ const ProgressContents = ({ text }) => {
       <ProgressBarBox>
         <ProgressBar />
       </ProgressBarBox>
-      <Timer type={"minute"} second={1000}></Timer>
+      {/*고급 level일 경우에만 Timer 설정 */}
+      {level === "high" && <Timer type={"minute"} second={1000} />}
       <TextBox>{text}</TextBox>
       <ContentsBox>
         {/*도움말 버튼 */}

--- a/src/pages/ProgressContents.jsx
+++ b/src/pages/ProgressContents.jsx
@@ -5,8 +5,8 @@ import { Outlet } from "react-router-dom";
 import Button from "../components/button/Button";
 import { useState } from "react";
 import Modal from "../components/Modal";
-import { useAtomValue, useSetAtom } from "jotai";
-import { levelAtom, writeSecondCount } from "../store/atom";
+import { useAtomValue } from "jotai";
+import { levelAtom } from "../store/atom";
 
 //ProgressBar+ContentsBox Container
 const ProgressContentsContainer = styled.div`

--- a/src/pages/main/Main.jsx
+++ b/src/pages/main/Main.jsx
@@ -68,7 +68,7 @@ function Main() {
       alert("이름을 입력해주세요.");
       return;
     }
-    localStorage.setItem("name", name);
+    sessionStorage.setItem("name", name);
     navigate("/select-mode");
   };
   return (

--- a/src/pages/main/Main.jsx
+++ b/src/pages/main/Main.jsx
@@ -62,11 +62,13 @@ function Main() {
     setName(name);
   };
 
+  //시작하기 클릭 시
   const handleClick = () => {
     if (name === "") {
       alert("이름을 입력해주세요.");
       return;
     }
+    localStorage.setItem("name", name);
     navigate("/select-mode");
   };
   return (


### PR DESCRIPTION
## 📝작업 내용
<img src ='https://github.com/user-attachments/assets/9bd86e81-a227-4e75-a54f-8238e5a216ad' width='500px'/><br><br>
### ✅ 사용자 이름 세션스토리지에 저장 
### ✅  난이도 별로 타이머 출력 변경
* 타이머 컴포넌트가 출력되지 않는 초급, 중급에서는 clearInterval을 실행
* minute 타이머 15분으로 변경 (16:40초로 설정돼있어서 100초 뺐습니다)
### ✅  타이머 제어
 1) 모달창이 켜질 시 타이머가 꺼지고, 모달창이 꺼질 시 타이머가 재개됨
* 모달이 열려있는지 열려있지 않는지 여부를 부모 컴포넌트에서 props로 보내줌
* 모달이 열려있는 경우 타이머 멈춤
* 모달이 닫혀있는 경우는 총 2가지 <br>
**- 타이머가 작동된 적이 없다** (secondCount / minuteCount가 존재하지 않는다) : second, second-100 값으로 초기화 (영주가 작성한 부분과 동일)
**- 타이머가 작동 중이었고, 모달 때문에 잠깐 멈췄다** : 초기화x, 모달창 켜기 전 값에서부터 시작 <br>
기존 코드로는 모달창이 꺼지면서 타이머가 재렌더링 될 때 항상 초기화의 과정을 거치게 됨 (useEffect 구문이 돌아가면서) 이미 전에 카운트 된 이력이 있다면 초기화를 거치지 않도록 코드를 변경
 2) useLocation을 이용하여 페이지 별로 타이머 제어
* step5 (예매 성공) 페이지에서는 타이머를 멈추고, 사용자가 성공했음을 보여줘야 함
useLocation을 통해 step5 페이지 위치일 경우 타이머를 멈추도록 설정
* step0 (고급레벨 첫 화면) 페이지에서는 타이머를 멈춰두고 15분으로 리셋해야 함 
useLocation을 통해 step0 페이지일 경우 타이머를 리셋 (second-100) 하고 멈추도록 설정함


## 💬리뷰 요구사항
### ✅ 세션스토리지 사용 이유
* 로컬 스토리지에 저장된 값은 사이트를 꺼도 사라지지 않음. Main화면에선 '세션스토리지'에 사용자 이름을 받아 웹사이트를 끌 경우 사라지도록 설정함
### ✅ 추가로 타이머의 제어가 필요한 부분이 있을지