### PR TITLE
Refactor: 포스터 날짜 및 시간 포맷 변경

### DIFF
--- a/src/components/calender/SelectCalender.jsx
+++ b/src/components/calender/SelectCalender.jsx
@@ -1,6 +1,6 @@
 import { useState, useEffect } from "react";
 import { useAtom } from "jotai";
-import { selectedPosterAtom, levelAtom } from "../../store/atom";
+import { selectedPosterAtom, levelAtom, postersAtom } from "../../store/atom";
 import { StyledCalendar, StyledCalendarWrapper } from "./calenderStyles";
 
 const SelectCalender = ({ onDateSelect }) => {
@@ -8,7 +8,7 @@ const SelectCalender = ({ onDateSelect }) => {
   const [activeStartDate, setActiveStartDate] = useState(new Date());
   const [level] = useAtom(levelAtom);
   const [selectedPoster] = useAtom(selectedPosterAtom);
-  const posterDates = ["2024-07-26", "2024-06-30", "2024-08-11", "2024-07-27"];
+  const [posters] = useAtom(postersAtom);
   const [posterId, setPosterId] = useState(0);
 
   useEffect(() => {
@@ -20,12 +20,13 @@ const SelectCalender = ({ onDateSelect }) => {
   }, [level, selectedPoster]);
 
   useEffect(() => {
-    const initialDate = posterDates[posterId];
-    if (initialDate) {
-      setSelectedDate(new Date(initialDate));
-      setActiveStartDate(new Date(initialDate));
+    const poster = posters[posterId];
+    if (poster && poster.date && poster.date.length > 0) {
+      const initialDate = new Date(poster.date[0]); // 첫 번째 날짜를 사용
+      setSelectedDate(initialDate);
+      setActiveStartDate(initialDate);
     }
-  }, [posterId]);
+  }, [posterId, posters]);
 
   const handleDateChange = (date) => {
     setSelectedDate(date);

--- a/src/components/calender/SelectCalender.jsx
+++ b/src/components/calender/SelectCalender.jsx
@@ -1,15 +1,31 @@
 import { useState, useEffect } from "react";
+import { useAtom } from "jotai";
+import { selectedPosterAtom, levelAtom } from "../../store/atom";
 import { StyledCalendar, StyledCalendarWrapper } from "./calenderStyles";
 
-const SelectCalender = ({ onDateSelect, initialDate }) => {
-  const [selectedDate, setSelectedDate] = useState(initialDate);
+const SelectCalender = ({ onDateSelect }) => {
+  const [selectedDate, setSelectedDate] = useState(new Date());
   const [activeStartDate, setActiveStartDate] = useState(new Date());
+  const [level] = useAtom(levelAtom);
+  const [selectedPoster] = useAtom(selectedPosterAtom);
+  const posterDates = ["2024-07-26", "2024-06-30", "2024-08-11", "2024-07-27"];
+  const [posterId, setPosterId] = useState(0);
 
   useEffect(() => {
+    if (level === "low" || level === "middle") {
+      setPosterId(0);
+    } else {
+      setPosterId(selectedPoster);
+    }
+  }, [level, selectedPoster]);
+
+  useEffect(() => {
+    const initialDate = posterDates[posterId];
     if (initialDate) {
       setSelectedDate(new Date(initialDate));
+      setActiveStartDate(new Date(initialDate));
     }
-  }, [initialDate]);
+  }, [posterId]);
 
   const handleDateChange = (date) => {
     setSelectedDate(date);

--- a/src/components/poster/Poster.jsx
+++ b/src/components/poster/Poster.jsx
@@ -7,7 +7,7 @@ const PosterImage = styled.img`
   width: 220px;
   height: 307px;
   object-fit: cover; // 이미지 크기를 전부 통일하게 위해 사용
-  margin: 10px;
+  padding: 10px;
 `;
 
 // json 파일에서 저장해둔 포스터 사진 src을 불러옴.

--- a/src/components/poster/PosterInfo.jsx
+++ b/src/components/poster/PosterInfo.jsx
@@ -3,6 +3,7 @@ import styled from "styled-components";
 import Poster from "./Poster";
 import { useAtom } from "jotai";
 import { postersAtom, levelAtom } from "../../store/atom";
+import { formatDateRange } from "../../util/date";
 
 // 공연 제목
 const PosterTitle = styled.h2`
@@ -53,7 +54,7 @@ const PosterInfo = ({ id }) => {
       <PosterTitle>{poster.title_ko}</PosterTitle>
       <Poster id={id} />
       <PosterVenue>장소: {poster.venue}</PosterVenue>
-      <PosterTime>시간: {poster.date}</PosterTime>
+      <PosterTime>시간: {formatDateRange(poster.date)}</PosterTime>
       <PosterTime>관람등급: {poster.age}</PosterTime>
     </PosterContainer>
   );

--- a/src/components/poster/PosterList.jsx
+++ b/src/components/poster/PosterList.jsx
@@ -3,6 +3,7 @@ import styled from "styled-components";
 import Poster from "./Poster";
 import { useAtom } from "jotai";
 import { postersAtom, levelAtom } from "../../store/atom";
+import { formatDateRange } from "../../util/date";
 import AnimationArea from "../Animation";
 
 // 공연 제목
@@ -120,7 +121,7 @@ const PosterList = ({ onPosterClick }) => {
                 <PosterInfo>
                   <PosterTitle>{poster.title_ko}</PosterTitle>
                   <PosterVenue>장소: {poster.venue}</PosterVenue>
-                  <PosterTime>시간: {poster.date}</PosterTime>
+                  <PosterTime>시간: {formatDateRange(poster.date)}</PosterTime>
                 </PosterInfo>
               </>
             )}

--- a/src/components/poster/poster.json
+++ b/src/components/poster/poster.json
@@ -5,7 +5,7 @@
     "title_ko": "노엘 갤러거 하이 플라잉 버즈",
     "title_en": "Noel Gallagher's High Flying Birds",
     "venue": "일산 킨텍스 제 1전시장 1, 2홀",
-    "date": "2024년 7월 26일 (금)",
+    "date": ["2024-07-26"],
     "time": "오후 8시",
     "age": "만 12세 이상",
     "price": {
@@ -22,7 +22,7 @@
     "title_ko": "뮤지컬 벤자민 버튼",
     "title_en": "Benjamin Button",
     "venue": "세종문화회관 M씨어터",
-    "date": "2024년 5월 11일(토) ~ 6월 30일(일)",
+    "date": ["2024-05-11", "2024-06-30"],
     "time": "화,목 7시 30분 / 수,금,토,공휴일 3시, 7시 30분 / 일 3시",
     "age": " 14세 이상",
     "price": {
@@ -37,7 +37,7 @@
     "src": "../../src/assests/images/posters/poster-trot.svg",
     "title_ko": "트롯 3파전 콘서트 - 창원",
     "venue": "창원컨벤션센터 2,3홀",
-    "date": "2024년 08월 11일(일)",
+    "date": ["2024-08-11"],
     "time": "17시 00분",
     "age": "만8세이상",
     "price": {
@@ -50,7 +50,7 @@
     "src": "../../src/assests/images/posters/poster-leechanwon.svg",
     "title_ko": "[수원] 2024 이찬원 콘서트 '찬가(燦歌)'",
     "venue": "수원 실내 체육관",
-    "date": "24년 7월 27일(토) ~ 28일(일)",
+    "date": ["2024-07-27", "2024-07-28"],
     "time": "오후 5시",
     "age": "만 7세 이상(미취학아동이상)",
     "price": {

--- a/src/components/poster/poster.json
+++ b/src/components/poster/poster.json
@@ -6,7 +6,9 @@
     "title_en": "Noel Gallagher's High Flying Birds",
     "venue": "일산 킨텍스 제 1전시장 1, 2홀",
     "date": ["2024-07-26"],
-    "time": "오후 8시",
+    "time": {
+      "default": "20:00"
+    },
     "age": "만 12세 이상",
     "price": {
       "스탠딩 P석": "132,000원",
@@ -23,8 +25,15 @@
     "title_en": "Benjamin Button",
     "venue": "세종문화회관 M씨어터",
     "date": ["2024-05-11", "2024-06-30"],
-    "time": "화,목 7시 30분 / 수,금,토,공휴일 3시, 7시 30분 / 일 3시",
-    "age": " 14세 이상",
+    "time": {
+      "Tue": ["19:30"],
+      "Thu": ["19:30"],
+      "Wed": ["15:00", "19:30"],
+      "Fri": ["15:00", "19:30"],
+      "Sat": ["15:00", "19:30"],
+      "Sun": ["15:00"]
+    },
+    "age": "14세 이상",
     "price": {
       "VIP석": "120,000원",
       "R석": "100,000원",
@@ -36,10 +45,13 @@
     "id": 2,
     "src": "../../src/assests/images/posters/poster-trot.svg",
     "title_ko": "트롯 3파전 콘서트 - 창원",
+    "title_en": "Trot 3-Way Concert - Changwon",
     "venue": "창원컨벤션센터 2,3홀",
     "date": ["2024-08-11"],
-    "time": "17시 00분",
-    "age": "만8세이상",
+    "time": {
+      "default": "17:00"
+    },
+    "age": "만 8세 이상",
     "price": {
       "VIP석": "132,000원",
       "R석": "110,000원"
@@ -49,10 +61,13 @@
     "id": 3,
     "src": "../../src/assests/images/posters/poster-leechanwon.svg",
     "title_ko": "[수원] 2024 이찬원 콘서트 '찬가(燦歌)'",
+    "title_en": "2024 Lee Chan Won Concert 'Changa'",
     "venue": "수원 실내 체육관",
     "date": ["2024-07-27", "2024-07-28"],
-    "time": "오후 5시",
-    "age": "만 7세 이상(미취학아동이상)",
+    "time": {
+      "default": "17:00"
+    },
+    "age": "만 7세 이상(미취학아동 이상)",
     "price": {
       "VIP석": "154,000원",
       "R석": "143,000원",

--- a/src/pages/practiceMode/step1/SelectRound.jsx
+++ b/src/pages/practiceMode/step1/SelectRound.jsx
@@ -55,6 +55,7 @@ const SelectRound = () => {
   const [roundSelected, setRoundSelected] = useState(false);
   const [animationStep, setAnimationStep] = useState(0);
   const [timesButtons, setTimesButtons] = useState([]);
+  const [correctRound, setCorrectRound] = useState(null); // 정답 회차 저장
   const navigate = useNavigate();
 
   useEffect(() => {
@@ -79,6 +80,11 @@ const SelectRound = () => {
       setAnimationStep(1);
       const timesArray = formatTime(posterTimes, formattedDate);
       setTimesButtons(timesArray);
+
+      // 회차 데이터에서 첫 번째 회차를 정답으로 설정
+      if (timesArray.length > 0) {
+        setCorrectRound(timesArray[0]);
+      }
     } else {
       alert("날짜를 다시 선택해주세요.");
     }
@@ -87,9 +93,13 @@ const SelectRound = () => {
   // 회차 선택
   const handleRoundClick = (time) => {
     if (dateSelected) {
-      alert(`${time}으로 공연을 예매합니다.`);
-      setRoundSelected(true);
-      setAnimationStep(2);
+      if (time === correctRound) {
+        alert(`${time}으로 공연을 예매합니다.`);
+        setRoundSelected(true);
+        setAnimationStep(2);
+      } else {
+        alert("회차를 다시 선택해주세요.");
+      }
     } else {
       alert("먼저 올바른 날짜를 선택해주세요.");
     }

--- a/src/pages/practiceMode/step1/SelectRound.jsx
+++ b/src/pages/practiceMode/step1/SelectRound.jsx
@@ -7,7 +7,8 @@ import { useAtom } from "jotai";
 import {
   selectedPosterAtom,
   levelAtom,
-  progressAtom
+  progressAtom,
+  postersAtom
 } from "../../../store/atom";
 import AnimationArea from "../../../components/Animation";
 import { useNavigate } from "react-router-dom";
@@ -15,8 +16,6 @@ import { useNavigate } from "react-router-dom";
 const Container = styled.div`
   display: flex;
   justify-content: space-between;
-  width: 1320px;
-  flex-shrink: 0;
 `;
 
 const LeftSection = styled.div`
@@ -33,8 +32,6 @@ const RightSection = styled.div`
   flex-direction: column;
   justify-content: center;
   align-items: flex-start;
-  gap: 20px;
-  margin-top: 20px;
 `;
 
 const RoundWrapper = styled.div`
@@ -51,27 +48,40 @@ const SelectRound = () => {
   const [, setProgress] = useAtom(progressAtom);
   const [selectedPoster] = useAtom(selectedPosterAtom);
   const [currentLevel] = useAtom(levelAtom);
+  const [posters] = useAtom(postersAtom); // 포스터 데이터 가져오기
   const [posterId, setPosterId] = useState(0);
   const [dateSelected, setDateSelected] = useState(false);
   const [roundSelected, setRoundSelected] = useState(false);
   const [animationStep, setAnimationStep] = useState(0);
   const navigate = useNavigate();
-  const posterDates = ["2024-07-26", "2024-06-30", "2024-08-11", "2024-07-27"];
 
   useEffect(() => {
     setProgress(1);
     if (currentLevel === "low" || currentLevel === "middle") {
       setPosterId(0);
     } else {
-      setPosterId(selectedPoster); // 나머지 경우 포스터 선택 가능
+      setPosterId(selectedPoster);
     }
   }, [currentLevel, setLevel, setProgress, selectedPoster]);
 
+  const poster = posters[posterId];
+  const posterDates = poster ? poster.date : [];
+
   // 날짜 정답 지정
   const handleDateSelect = (formattedDate) => {
-    const correctDate = posterDates[posterId];
+    console.log("Selected Date:", formattedDate);
+    console.log("Poster Dates:", posterDates);
 
-    if (formattedDate === correctDate) {
+    // 포스터 날짜 배열에서 첫 번째 날짜를 정답으로 설정
+    const correctDate = posterDates.length > 0 ? posterDates[0] : "";
+
+    // 날짜 비교 시 시간 부분 제거
+    const formattedDateWithoutTime = formattedDate.split("T")[0];
+    const correctDateWithoutTime = correctDate.split("T")[0];
+
+    console.log("Correct Date:", correctDateWithoutTime);
+
+    if (formattedDateWithoutTime === correctDateWithoutTime) {
       setDateSelected(true);
       setAnimationStep(1);
     } else {
@@ -107,7 +117,9 @@ const SelectRound = () => {
             <AnimationArea $focus={animationStep === 0}>
               <SelectCalender
                 onDateSelect={handleDateSelect}
-                initialDate={new Date(posterDates[posterId])}
+                initialDate={
+                  posterDates.length > 0 ? new Date(posterDates[0]) : new Date()
+                }
               />
             </AnimationArea>
             <RoundWrapper>
@@ -136,7 +148,9 @@ const SelectRound = () => {
           <>
             <SelectCalender
               onDateSelect={handleDateSelect}
-              initialDate={new Date(posterDates[posterId])}
+              initialDate={
+                posterDates.length > 0 ? new Date(posterDates[0]) : new Date()
+              }
             />
             <RoundWrapper>
               <p>회차</p>

--- a/src/pages/practiceMode/step1/SelectRound.jsx
+++ b/src/pages/practiceMode/step1/SelectRound.jsx
@@ -12,6 +12,7 @@ import {
 } from "../../../store/atom";
 import AnimationArea from "../../../components/Animation";
 import { useNavigate } from "react-router-dom";
+import formatTime from "../../../util/time";
 
 const Container = styled.div`
   display: flex;
@@ -53,6 +54,7 @@ const SelectRound = () => {
   const [dateSelected, setDateSelected] = useState(false);
   const [roundSelected, setRoundSelected] = useState(false);
   const [animationStep, setAnimationStep] = useState(0);
+  const [timesButtons, setTimesButtons] = useState([]);
   const navigate = useNavigate();
 
   useEffect(() => {
@@ -66,31 +68,26 @@ const SelectRound = () => {
 
   const poster = posters[posterId];
   const posterDates = poster ? poster.date : [];
+  const posterTimes = poster ? poster.time : {};
 
   // 날짜 정답 지정
   const handleDateSelect = (formattedDate) => {
-    console.log("Selected Date:", formattedDate);
-    console.log("Poster Dates:", posterDates);
+    const correctDate = posterDates[0]; // 날짜 배열의 첫 번째 날짜를 정답으로 설정
 
-    // 포스터 날짜 배열에서 첫 번째 날짜를 정답으로 설정
-    const correctDate = posterDates.length > 0 ? posterDates[0] : "";
-
-    // 날짜 비교 시 시간 부분 제거
-    const formattedDateWithoutTime = formattedDate.split("T")[0];
-    const correctDateWithoutTime = correctDate.split("T")[0];
-
-    console.log("Correct Date:", correctDateWithoutTime);
-
-    if (formattedDateWithoutTime === correctDateWithoutTime) {
+    if (formattedDate === correctDate) {
       setDateSelected(true);
       setAnimationStep(1);
+      const timesArray = formatTime(posterTimes, formattedDate);
+      setTimesButtons(timesArray);
     } else {
       alert("날짜를 다시 선택해주세요.");
     }
   };
 
-  const handleRoundClick = () => {
+  // 회차 선택
+  const handleRoundClick = (time) => {
     if (dateSelected) {
+      alert(`${time}으로 공연을 예매합니다.`);
       setRoundSelected(true);
       setAnimationStep(2);
     } else {
@@ -112,53 +109,60 @@ const SelectRound = () => {
         <PosterInfo id={posterId} />
       </LeftSection>
       <RightSection>
-        {currentLevel === "low" ? (
-          <>
-            <AnimationArea $focus={animationStep === 0}>
-              <SelectCalender
-                onDateSelect={handleDateSelect}
-                initialDate={
-                  posterDates.length > 0 ? new Date(posterDates[0]) : new Date()
-                }
-              />
-            </AnimationArea>
-            <RoundWrapper>
-              <p>회차</p>
-              {animationStep >= 1 ? (
-                <AnimationArea $focus={animationStep === 1}>
+        <SelectCalender
+          onDateSelect={handleDateSelect}
+          initialDate={
+            posterDates.length > 0 ? new Date(posterDates[0]) : new Date()
+          }
+        />
+        <RoundWrapper>
+          <p>회차</p>
+          {currentLevel === "low" ? (
+            <>
+              <AnimationArea $focus={animationStep === 1}>
+                {timesButtons.length > 0 ? (
+                  timesButtons.map((time, index) => (
+                    <Button
+                      key={index}
+                      text={`${index + 1}회 - ${time}`}
+                      type="outline"
+                      onClick={() => handleRoundClick(time)}
+                    />
+                  ))
+                ) : (
                   <Button
-                    text="1회"
+                    text="날짜 선택 후 확인"
                     type="outline"
-                    onClick={handleRoundClick}
+                    onClick={() => handleRoundClick("날짜 선택 후 확인")}
                   />
-                </AnimationArea>
-              ) : (
-                <Button text="1회" type="outline" onClick={handleRoundClick} />
-              )}
-              {animationStep >= 2 ? (
-                <AnimationArea $focus={animationStep === 2}>
-                  <Button text="예매하기" onClick={handleReserveClick} />
-                </AnimationArea>
-              ) : (
+                )}
+              </AnimationArea>
+              <AnimationArea $focus={animationStep === 2}>
                 <Button text="예매하기" onClick={handleReserveClick} />
+              </AnimationArea>
+            </>
+          ) : (
+            <>
+              {timesButtons.length > 0 ? (
+                timesButtons.map((time, index) => (
+                  <Button
+                    key={index}
+                    text={`${index + 1}회 - ${time}`}
+                    type="outline"
+                    onClick={() => handleRoundClick(time)}
+                  />
+                ))
+              ) : (
+                <Button
+                  text="날짜 선택 후 확인"
+                  type="outline"
+                  onClick={() => handleRoundClick("날짜 선택 후 확인")}
+                />
               )}
-            </RoundWrapper>
-          </>
-        ) : (
-          <>
-            <SelectCalender
-              onDateSelect={handleDateSelect}
-              initialDate={
-                posterDates.length > 0 ? new Date(posterDates[0]) : new Date()
-              }
-            />
-            <RoundWrapper>
-              <p>회차</p>
-              <Button text="1회" type="outline" onClick={handleRoundClick} />
               <Button text="예매하기" onClick={handleReserveClick} />
-            </RoundWrapper>
-          </>
-        )}
+            </>
+          )}
+        </RoundWrapper>
       </RightSection>
     </Container>
   );

--- a/src/pages/practiceMode/step1/SelectRound.jsx
+++ b/src/pages/practiceMode/step1/SelectRound.jsx
@@ -59,10 +59,9 @@ const SelectRound = () => {
   const posterDates = ["2024-07-26", "2024-06-30", "2024-08-11", "2024-07-27"];
 
   useEffect(() => {
-    // setLevel(currentLevel);
     setProgress(1);
-    if (currentLevel === "low") {
-      setPosterId(0); // 초급일 경우 고정
+    if (currentLevel === "low" || currentLevel === "middle") {
+      setPosterId(0);
     } else {
       setPosterId(selectedPoster); // 나머지 경우 포스터 선택 가능
     }

--- a/src/util/date.js
+++ b/src/util/date.js
@@ -1,0 +1,20 @@
+// 공연 날짜가 하루일 때
+export const formatDate = (dateString) => {
+  const date = new Date(dateString);
+  const year = date.getFullYear();
+  const month = date.getMonth() + 1;
+  const day = date.getDate();
+  const weekDay = ["일", "월", "화", "수", "목", "금", "토"][date.getDay()];
+
+  return `${year}년 ${month}월 ${day}일(${weekDay})`;
+};
+
+// 공연 날짜가 범위로 주어질 때
+export const formatDateRange = (dates) => {
+  if (dates.length === 1) {
+    return formatDate(dates[0]);
+  } else if (dates.length === 2) {
+    return `${formatDate(dates[0])} ~ ${formatDate(dates[1])}`;
+  }
+  return "";
+};

--- a/src/util/time.js
+++ b/src/util/time.js
@@ -1,0 +1,44 @@
+const formatTime = (timeData, date) => {
+  const formatSingleTime = (time) => {
+    const [hours, minutes] = time.split(":");
+    let formattedHours = parseInt(hours, 10);
+    let amPm = "오후";
+
+    if (formattedHours < 12) {
+      if (formattedHours === 0) {
+        formattedHours = 12;
+      }
+      amPm = "오전";
+    } else if (formattedHours === 12) {
+      amPm = "오후";
+    } else {
+      formattedHours -= 12;
+      amPm = "오후";
+    }
+
+    const formattedMinutes = minutes ? `${minutes}분` : "";
+    return `${amPm} ${formattedHours}시 ${formattedMinutes}`.trim();
+  };
+
+  // 시간이 하나로 정해진 경우 그대로 반환
+  if (typeof timeData === "string") {
+    return [formatSingleTime(timeData)];
+  }
+
+  // 시간이 요일마다 다른 경우 해당 요일의 시간만 반환
+  if (typeof timeData === "object") {
+    const weekday = new Date(date).toLocaleDateString("en-GB", {
+      weekday: "short"
+    });
+    const timesArray = timeData[weekday] || timeData.default || [];
+
+    if (Array.isArray(timesArray)) {
+      return timesArray.map(formatSingleTime);
+    }
+    return [formatSingleTime(timesArray)];
+  }
+
+  return [];
+};
+
+export default formatTime;


### PR DESCRIPTION
# 📝작업 내용
- 고급 난이도에서만 캘린더 월 자동 설정되는 버그 수정
- 포스터 정보 json에서 date, time 정보 포맷 변경
  
  - 변경한 이유?: 원래 단순 하드코딩해서 정답 설정했으나, 나중에 실전 모드 만들때 또 정답 설정할텐데.. 미리 리팩토링해야 컴포넌트 돌려 쓰기 편할 것 같아서 리팩토링함. 
 
  -  정답의 경우 그냥 예매 기간 중 **첫번째 날짜** 및 **첫번째 회차** 로 지정해두었는데 혹시 바꾸려면 그 부분을 수정해야 함.
- 회차 정보가 원래 1회로만 떴었는데, 이제 선택한 날짜에 맞게 시간 정보가 동적으로 변경됨. 여러 개면 여러 버튼이 뜸! 
- 포맷 유틸 함수들 추가 
  - `formatTime`: 시간 정보 포맷 변경 (17:00 -> 오후 5시 00분)
  - `formatDateRange`: 날짜 정보 하나면 그것만 출력, 기간이면 범위로 출력

## 스크린샷 (선택)
![2024-08-16 13 56 32](https://github.com/user-attachments/assets/a12d234f-030d-4332-aec1-a26227f9ecb5)

## 💬리뷰 요구사항
테스트해보긴 했는데 혹시 오류있는 부분 있으면 알려조용😶
