### PR TITLE
Refactor: 버튼 컴포넌트 module.css에 theme 적용 및 테스트

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -3,10 +3,12 @@ import { RouterProvider } from "react-router-dom";
 import router from "./routes";
 import theme from "./styles/theme";
 import { ThemeProvider } from "styled-components";
+import ButtonStyle from "./styles/ButtonStyle";
 
 function App() {
   return (
     <ThemeProvider theme={theme}>
+      <ButtonStyle />
       <RouterProvider router={router} />
     </ThemeProvider>
   );

--- a/src/components/ProgressBar.jsx
+++ b/src/components/ProgressBar.jsx
@@ -1,6 +1,7 @@
 import styled from "styled-components";
 import { useAtomValue } from "jotai";
 import { progressAtom, themeSiteAtom } from "../store/atom";
+
 const ProgressBarContainer = styled.div`
   display: flex;
   width: 100%;
@@ -16,6 +17,14 @@ const ProgressStep = styled.div`
   align-items: center;
 `;
 
+const getColor = (props, type) => {
+  if (props.$themeSite === "practice") {
+    return "var(--key-color)";
+  } else {
+    return props.theme[props.$themeSite][type];
+  }
+};
+
 const StepNumber = styled.div`
   display: flex;
   align-items: center;
@@ -24,18 +33,17 @@ const StepNumber = styled.div`
   height: 30px;
   border-radius: 50%;
   background-color: ${(props) =>
-    props.$active ? "var(--key-color)" : "var(--fill-color)"};
-  color: #ffff;
+    props.$active ? getColor(props, "grayColor") : "var(--fill-color)"};
+  color: #fff;
   margin-bottom: 10px;
   font-family: "pretendardB";
 `;
+
 const StepLine = styled.div`
   width: 211px;
   height: 13px;
   background-color: ${(props) =>
-    props.$active
-      ? props.theme[props.$themeSite]["--key-color"]
-      : "var(--fill-color)"};
+    props.$active ? getColor(props, "grayColor") : "var(--fill-color)"};
   margin-bottom: 10px;
 
   &.rounded-start {
@@ -49,7 +57,7 @@ const StepLine = styled.div`
 const StepLabel = styled.div`
   font-size: 20px;
   color: ${(props) =>
-    props.$active ? "var(--key-color)" : "var(--text-color)"};
+    props.$active ? getColor(props, "grayColor") : "var(--text-color)"};
   text-align: center;
   font-family: "pretendardB";
   white-space: nowrap;
@@ -69,19 +77,24 @@ const ProgressBar = () => {
   return (
     <ProgressBarContainer>
       {steps.map((stepName, index) => (
-        <ProgressStep key={index} $active={progress >= index + 1}>
-          <StepNumber $active={progress == index + 1}>{index + 1}</StepNumber>
+        <ProgressStep key={index}>
+          <StepNumber $active={progress == index + 1} $themeSite={themeSite}>
+            {index + 1}
+          </StepNumber>
           <StepLine
             className={
               index == 0 ? "rounded-start" : index == 4 ? "rounded-end" : ""
             }
-            $active={progress >= index + 1}
+            $active={progress > index} // 이전 단계를 활성화 상태로 표시
             $themeSite={themeSite}
           />
-          <StepLabel $active={progress == index + 1}>{stepName}</StepLabel>
+          <StepLabel $active={progress == index + 1} $themeSite={themeSite}>
+            {stepName}
+          </StepLabel>
         </ProgressStep>
       ))}
     </ProgressBarContainer>
   );
 };
+
 export default ProgressBar;

--- a/src/components/button/Button.jsx
+++ b/src/components/button/Button.jsx
@@ -1,15 +1,21 @@
+// Button.jsx
 import React from "react";
+import { useAtom } from "jotai";
+import { themeSiteAtom } from "../../store/atom";
 import styles from "./Button.module.css";
 
 const Button = (props) => {
   const { text, onClick, type, icon, ...rest } = props;
+  const [currentTheme] = useAtom(themeSiteAtom);
+
+  const buttonClass = `${styles.button} ${
+    currentTheme ? styles[`button--${currentTheme}`] : ""
+  } ${
+    type === "outline" ? styles[`button--outline--${currentTheme}`] : ""
+  } ${type ? styles[`button--${type}`] : ""}`;
 
   return (
-    <button
-      className={`${styles.button} ${type ? styles[`button--${type}`] : ""}`}
-      onClick={onClick}
-      {...rest}
-    >
+    <button className={buttonClass} onClick={onClick} {...rest}>
       {icon && <img src={icon} alt="" className={styles.icon} />}
       {text}
     </button>

--- a/src/components/button/Button.module.css
+++ b/src/components/button/Button.module.css
@@ -78,50 +78,41 @@
   margin-bottom: 20px;
 }
 
-/* 사이트별 버튼 스타일 */
+/* 사이트별 디폴트 버튼 스타일 */
 .button--interpark {
   background-color: #d40000;
-  border: 1px solid #d40000;
 }
-
 .button--interpark:hover {
   background-color: #b50000;
 }
 
 .button--melonticket {
   background-color: #00ff00;
-  border: 1px solid #00ff00;
 }
-
 .button--melonticket:hover {
   background-color: #00b500;
 }
 
 .button--ticketlink {
   background-color: #d40000;
-  border: 1px solid #d40000;
 }
-
 .button--ticketlink:hover {
   background-color: #b50c00;
 }
 
 .button--yes24 {
   background-color: #00b7ff;
-  border: 1px solid #00b7ff;
 }
-
 .button--yes24:hover {
   background-color: #005bb5;
 }
 
-/* 아웃라인 버튼 스타일 */
+/* 사이트별 아웃라인 버튼 스타일 */
 .button--outline--interpark {
   border: 2px solid #d40000;
   background-color: transparent;
   color: #d40000;
 }
-
 .button--outline--interpark:hover {
   background-color: #ffeeee;
 }
@@ -131,7 +122,6 @@
   background-color: transparent;
   color: #00ff00;
 }
-
 .button--outline--melonticket:hover {
   background-color: #e0f5e0;
 }
@@ -141,7 +131,6 @@
   background-color: transparent;
   color: #d40000;
 }
-
 .button--outline--ticketlink:hover {
   background-color: #ffadad;
 }
@@ -151,7 +140,6 @@
   background-color: transparent;
   color: #00b7ff;
 }
-
 .button--outline--yes24:hover {
   background-color: #d0eaff;
 }

--- a/src/components/button/Button.module.css
+++ b/src/components/button/Button.module.css
@@ -77,3 +77,81 @@
   height: 100px;
   margin-bottom: 20px;
 }
+
+/* 사이트별 버튼 스타일 */
+.button--interpark {
+  background-color: #d40000;
+  border: 1px solid #d40000;
+}
+
+.button--interpark:hover {
+  background-color: #b50000;
+}
+
+.button--melonticket {
+  background-color: #00ff00;
+  border: 1px solid #00ff00;
+}
+
+.button--melonticket:hover {
+  background-color: #00b500;
+}
+
+.button--ticketlink {
+  background-color: #d40000;
+  border: 1px solid #d40000;
+}
+
+.button--ticketlink:hover {
+  background-color: #b50c00;
+}
+
+.button--yes24 {
+  background-color: #00b7ff;
+  border: 1px solid #00b7ff;
+}
+
+.button--yes24:hover {
+  background-color: #005bb5;
+}
+
+/* 아웃라인 버튼 스타일 */
+.button--outline--interpark {
+  border: 2px solid #d40000;
+  background-color: transparent;
+  color: #d40000;
+}
+
+.button--outline--interpark:hover {
+  background-color: #ffeeee;
+}
+
+.button--outline--melonticket {
+  border: 2px solid #00ff00;
+  background-color: transparent;
+  color: #00ff00;
+}
+
+.button--outline--melonticket:hover {
+  background-color: #e0f5e0;
+}
+
+.button--outline--ticketlink {
+  border: 2px solid #d40000;
+  background-color: transparent;
+  color: #d40000;
+}
+
+.button--outline--ticketlink:hover {
+  background-color: #ffadad;
+}
+
+.button--outline--yes24 {
+  border: 2px solid #00b7ff;
+  background-color: transparent;
+  color: #00b7ff;
+}
+
+.button--outline--yes24:hover {
+  background-color: #d0eaff;
+}

--- a/src/pages/Layout.jsx
+++ b/src/pages/Layout.jsx
@@ -12,15 +12,17 @@ const LayoutPage = styled.div`
 `;
 
 const Layout = () => {
-  //step을  포함하는 주소가 아니거나 step0라면
-  //세션 스토리지 초기화
   const path = useLocation().pathname;
 
   useEffect(() => {
-    if (path === "/progress/step0" || path === "/progress/step5") {
+    if (
+      path === "/" ||
+      path === "/progress/step0" ||
+      path === "/progress/step5"
+    ) {
       resetAtom();
     }
-  }, [path]); // isStep이 변경될 때만 실행됨
+  }, [path]); // path가 변경될 때만 실행됨
 
   return (
     <LayoutPage>

--- a/src/pages/ProgressContents.jsx
+++ b/src/pages/ProgressContents.jsx
@@ -6,7 +6,7 @@ import Button from "../components/button/Button";
 import { useState } from "react";
 import Modal from "../components/Modal";
 import { useAtomValue } from "jotai";
-import { levelAtom } from "../store/atom";
+import { themeSiteAtom, levelAtom } from "../store/atom";
 
 //ProgressBar+ContentsBox Container
 const ProgressContentsContainer = styled.div`
@@ -52,13 +52,18 @@ const ProgressContents = ({ text }) => {
   //레벨 별 타이머 출력 설정
   const level = useAtomValue(levelAtom);
   const [isModalOpen, setIsModalOpen] = useState(false);
+  const theme = useAtomValue(themeSiteAtom);
 
   const handleModalOpen = () => {
     setIsModalOpen(true);
   };
+
   const handleModalClose = () => {
     setIsModalOpen(false);
   };
+
+  // 실전 모드인 경우(테마 정보가 있는 경우) 도움말 버튼 숨기기
+  const showHelpButton = !theme;
 
   return (
     <ProgressContentsContainer>
@@ -74,14 +79,16 @@ const ProgressContents = ({ text }) => {
       <TextBox>{text}</TextBox>
       <ContentsBox>
         {/*도움말 버튼 */}
-        <ButtonContainer>
-          <Button
-            onClick={handleModalOpen}
-            text="도움이 필요하신가요?"
-            type="help"
-          />
-        </ButtonContainer>
-        {/*도움말 모달창*/}
+        {showHelpButton && (
+          <ButtonContainer>
+            <Button
+              onClick={handleModalOpen}
+              text="도움이 필요하신가요?"
+              type="help"
+            />
+          </ButtonContainer>
+        )}
+        {/* 도움말 모달창 */}
         {isModalOpen && (
           <Modal onClick={handleModalClose} contents="내용입니다" />
         )}

--- a/src/pages/challengeMode/interpark/SelectRoundInterpark.jsx
+++ b/src/pages/challengeMode/interpark/SelectRoundInterpark.jsx
@@ -135,11 +135,15 @@ const SelectRoundInterpark = () => {
           ) : (
             <Button
               text="날짜 선택 후 확인"
-              type="outline"
+              type="outline--interpark"
               onClick={() => handleRoundClick("날짜 선택 후 확인")}
             />
           )}
-          <Button text="예매하기" onClick={handleReserveClick} />
+          <Button
+            text="예매하기"
+            type="interpark"
+            onClick={handleReserveClick}
+          />
         </RoundWrapper>
       </RightSection>
     </Container>

--- a/src/pages/challengeMode/interpark/SelectRoundInterpark.jsx
+++ b/src/pages/challengeMode/interpark/SelectRoundInterpark.jsx
@@ -128,22 +128,18 @@ const SelectRoundInterpark = () => {
               <Button
                 key={index}
                 text={`${index + 1}회 - ${time}`}
-                type="outline--interpark"
+                type="outline"
                 onClick={() => handleRoundClick(time)}
               />
             ))
           ) : (
             <Button
               text="날짜 선택 후 확인"
-              type="outline--interpark"
+              type="outline"
               onClick={() => handleRoundClick("날짜 선택 후 확인")}
             />
           )}
-          <Button
-            text="예매하기"
-            type="interpark"
-            onClick={handleReserveClick}
-          />
+          <Button text="예매하기" onClick={handleReserveClick} />
         </RoundWrapper>
       </RightSection>
     </Container>

--- a/src/pages/challengeMode/interpark/SelectRoundInterpark.jsx
+++ b/src/pages/challengeMode/interpark/SelectRoundInterpark.jsx
@@ -1,0 +1,149 @@
+// SelectRoundInterpark.jsx
+import React, { useEffect, useState } from "react";
+import PosterInfo from "../../../components/poster/PosterInfo";
+import SelectCalender from "../../../components/calender/SelectCalender";
+import Button from "../../../components/button/Button";
+import styled from "styled-components";
+import { useAtom } from "jotai";
+import {
+  themeSiteAtom,
+  selectedPosterAtom,
+  levelAtom,
+  progressAtom,
+  postersAtom
+} from "../../../store/atom";
+import { useNavigate } from "react-router-dom";
+import formatTime from "../../../util/time";
+
+const Container = styled.div`
+  display: flex;
+  justify-content: space-between;
+`;
+
+const LeftSection = styled.div`
+  width: 600px;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+`;
+
+const RightSection = styled.div`
+  width: 600px;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: flex-start;
+`;
+
+const RoundWrapper = styled.div`
+  width: 220px;
+  display: flex;
+  flex-direction: column;
+  margin-left: 20px;
+  align-items: left;
+  padding: 5px;
+`;
+
+const SelectRoundInterpark = () => {
+  const [, setLevel] = useAtom(levelAtom);
+  const [, setProgress] = useAtom(progressAtom);
+  const [selectedPoster] = useAtom(selectedPosterAtom);
+  const [posters] = useAtom(postersAtom); // 포스터 데이터 가져오기
+  const [posterId, setPosterId] = useState(0);
+  const [dateSelected, setDateSelected] = useState(false);
+  const [roundSelected, setRoundSelected] = useState(false);
+  const [timesButtons, setTimesButtons] = useState([]);
+  const [correctRound, setCorrectRound] = useState(null); // 정답 회차 저장
+  const navigate = useNavigate();
+  const [, setThemeSite] = useAtom(themeSiteAtom);
+
+  useEffect(() => {
+    setProgress(1);
+    setThemeSite("interpark"); // Interpark 테마 적용
+    setLevel("high"); // 고급 난이도 설정
+    setPosterId(0);
+  }, [setLevel, setProgress, selectedPoster, setThemeSite]);
+
+  const poster = posters[posterId];
+  const posterDates = poster ? poster.date : [];
+  const posterTimes = poster ? poster.time : {};
+
+  // 날짜 정답 지정
+  const handleDateSelect = (formattedDate) => {
+    const correctDate = posterDates[0]; // 날짜 배열의 첫 번째 날짜를 정답으로 설정
+
+    if (formattedDate === correctDate) {
+      setDateSelected(true);
+      const timesArray = formatTime(posterTimes, formattedDate);
+      setTimesButtons(timesArray);
+
+      // 회차 데이터에서 첫 번째 회차를 정답으로 설정
+      if (timesArray.length > 0) {
+        setCorrectRound(timesArray[0]);
+      }
+    } else {
+      alert("날짜를 다시 선택해주세요.");
+    }
+  };
+
+  // 회차 선택
+  const handleRoundClick = (time) => {
+    if (dateSelected) {
+      if (time === correctRound) {
+        alert(`${time}으로 공연을 예매합니다.`);
+        setRoundSelected(true);
+      } else {
+        alert("회차를 다시 선택해주세요.");
+      }
+    } else {
+      alert("먼저 올바른 날짜를 선택해주세요.");
+    }
+  };
+
+  const handleReserveClick = () => {
+    if (!roundSelected) {
+      alert("먼저 회차를 선택해주세요.");
+      return;
+    }
+    navigate("/interpark/step2");
+  };
+
+  return (
+    <Container>
+      <LeftSection>
+        <PosterInfo id={posterId} />
+      </LeftSection>
+      <RightSection>
+        <SelectCalender
+          onDateSelect={handleDateSelect}
+          initialDate={
+            posterDates.length > 0 ? new Date(posterDates[0]) : new Date()
+          }
+        />
+        <RoundWrapper>
+          <p>회차</p>
+          {timesButtons.length > 0 ? (
+            timesButtons.map((time, index) => (
+              <Button
+                key={index}
+                text={`${index + 1}회 - ${time}`}
+                type="outline--interpark"
+                onClick={() => handleRoundClick(time)}
+              />
+            ))
+          ) : (
+            <Button
+              text="날짜 선택 후 확인"
+              type="outline"
+              onClick={() => handleRoundClick("날짜 선택 후 확인")}
+            />
+          )}
+          <Button text="예매하기" onClick={handleReserveClick} />
+        </RoundWrapper>
+      </RightSection>
+    </Container>
+  );
+};
+
+export default SelectRoundInterpark;

--- a/src/pages/practiceMode/selectSite/selectSite.jsx
+++ b/src/pages/practiceMode/selectSite/selectSite.jsx
@@ -1,9 +1,14 @@
-import React from "react";
+import React, { useEffect } from "react";
 import styled from "styled-components";
 import { useNavigate } from "react-router-dom";
 import Button from "../../../components/button/Button";
 import { themeSiteAtom } from "../../../store/atom";
-import { useSetAtom } from "jotai";
+import { useSetAtom, useAtom } from "jotai";
+import interparkIcon from "../../../assests/images/icons/interpark.svg";
+import melonticketIcon from "../../../assests/images/icons/melonticket.svg";
+import tickelinkIcon from "../../../assests/images/icons/tickelink.svg";
+import yes24Icon from "../../../assests/images/icons/yes24.svg";
+
 const SelectSiteContainer = styled.div`
   display: flex;
   flex-direction: column;
@@ -11,10 +16,6 @@ const SelectSiteContainer = styled.div`
   justify-content: center;
   margin-top: 50px;
 `;
-import interparkIcon from "../../../assests/images/icons/interpark.svg";
-import melonticketIcon from "../../../assests/images/icons/melonticket.svg";
-import tickelinkIcon from "../../../assests/images/icons/tickelink.svg";
-import yes24Icon from "../../../assests/images/icons/yes24.svg";
 
 const Instructions = styled.p`
   margin-top: 20px;
@@ -35,19 +36,42 @@ const ButtonBox = styled.div`
 `;
 
 const SelectSite = () => {
-  const nav = useNavigate();
-  const setThemeSite = useSetAtom(themeSiteAtom);
+  const navigate = useNavigate();
+  const [themeSite, setThemeSite] = useAtom(themeSiteAtom);
+
+  useEffect(() => {
+    // 사이트 선택 시 default 테마를 적용
+    if (window.location.pathname === "/select-site") {
+      setThemeSite("practice");
+    }
+  }, [setThemeSite]);
+
   const sites = [
-    { name: "인터파크 티켓", icon: interparkIcon, path: "/interpark" },
-    { name: "멜론티켓", icon: melonticketIcon, path: "/melonticket" },
-    { name: "티켓링크", icon: tickelinkIcon, path: "/ticketlink" },
-    { name: "예스24(YES24)", icon: yes24Icon, path: "/yes24" }
+    {
+      name: "인터파크 티켓",
+      icon: interparkIcon,
+      path: "/interpark/step1", // 테마 적용 테스트 페이지
+      theme: "interpark"
+    },
+    {
+      name: "멜론티켓",
+      icon: melonticketIcon,
+      path: "/melonticket",
+      theme: "melonticket"
+    },
+    {
+      name: "티켓링크",
+      icon: tickelinkIcon,
+      path: "/ticketlink",
+      theme: "ticketlink"
+    },
+    { name: "예스24(YES24)", icon: yes24Icon, path: "/yes24", theme: "yes24" }
   ];
 
-  const handleClick = (path) => {
-    //site 종류를 sessionStorage에 저장
-    setThemeSite(path.replace("/", ""));
-    nav(path);
+  // 라우팅
+  const handleClick = (path, theme) => {
+    setThemeSite(theme);
+    navigate(path);
   };
 
   return (
@@ -62,7 +86,7 @@ const SelectSite = () => {
             <Button
               text={site.name}
               icon={site.icon}
-              onClick={() => handleClick(site.path)}
+              onClick={() => handleClick(site.path, site.theme)}
               type="mode"
             />
           </ButtonBox>

--- a/src/pages/practiceMode/step0/Intro.jsx
+++ b/src/pages/practiceMode/step0/Intro.jsx
@@ -2,6 +2,7 @@ import React, { useEffect } from "react";
 import styled from "styled-components";
 import { useNavigate } from "react-router-dom";
 import { useAtom } from "jotai";
+import { themeSiteAtom } from "../../../store/atom";
 import { levelAtom, progressAtom } from "../../../store/atom";
 import Button from "../../../components/button/Button";
 import AnimationArea from "../../../components/Animation";
@@ -19,6 +20,14 @@ const Intro = () => {
   const navigate = useNavigate();
   const [level] = useAtom(levelAtom);
   const [progress, setProgress] = useAtom(progressAtom);
+  const [themeSite, setThemeSite] = useAtom(themeSiteAtom);
+
+  useEffect(() => {
+    // 사이트 선택 시 default 테마를 적용
+    if (window.location.pathname === "/progress/step0") {
+      setThemeSite("practice");
+    }
+  }, [setThemeSite]);
 
   useEffect(() => {
     setProgress(0);

--- a/src/routes.jsx
+++ b/src/routes.jsx
@@ -9,6 +9,7 @@ import SelectSite from "./pages/practiceMode/selectSite/selectSite";
 import Intro from "./pages/practiceMode/step0/Intro";
 import SelectPerformance from "./pages/practiceMode/step1/SelectPerformance";
 import SelectRound from "./pages/practiceMode/step1/SelectRound";
+import SelectRoundInterpark from "./pages/challengeMode/interpark/SelectRoundInterpark";
 import SelectPayMethod from "./pages/practiceMode/step4/SelectPayMethod";
 import CardPay from "./pages/practiceMode/step4/CardPay";
 import Step5 from "./pages/practiceMode/step5/Step5";
@@ -63,6 +64,22 @@ const router = createBrowserRouter([
             path: "step4-2",
             element: <PrivateRoute element={<CardPay />} />,
             label: "카드 결제창"
+          },
+          {
+            path: "step5",
+            element: <PrivateRoute element={<Step5 />} />,
+            label: "예매 성공"
+          }
+        ]
+      },
+      {
+        path: "interpark",
+        element: <ProgressContents />,
+        children: [
+          {
+            path: "step1",
+            element: <PrivateRoute element={<SelectRoundInterpark />} />,
+            label: "날짜 및 회차 선택"
           },
           {
             path: "step5",

--- a/src/styles/ButtonStyle.jsx
+++ b/src/styles/ButtonStyle.jsx
@@ -1,0 +1,12 @@
+// 버튼 모듈 css 컬러 변수 전역 적용
+import { createGlobalStyle } from "styled-components";
+
+const ButtonStyle = createGlobalStyle`
+  :root {
+    --key-color: ${(props) => props.theme.keyColor};
+    --hover-color: ${(props) => props.theme.hoverColor};
+    --sub-color: ${(props) => props.theme.subColor};
+  }
+`;
+
+export default ButtonStyle;

--- a/src/styles/ThemeProvider.jsx
+++ b/src/styles/ThemeProvider.jsx
@@ -1,10 +1,9 @@
 // ThemeProvider.jsx
 import React, { createContext, useState, useContext, useEffect } from "react";
 import { useLocation } from "react-router-dom";
-import styles from "./variables.module.css";
-import theme from "./theme";
 import { useAtom } from "jotai";
 import { themeSiteAtom } from "../store/atom";
+import theme from "./theme";
 
 const ThemeContext = createContext();
 
@@ -33,7 +32,6 @@ export const ThemeProvider = ({ children }) => {
   }, [location, setCurrentTheme]);
 
   const themeStyles = {
-    "--button-color": theme.buttonColors[currentTheme],
     "--progress-bar-color": theme.progressBarColors[currentTheme]
   };
 

--- a/src/styles/theme.js
+++ b/src/styles/theme.js
@@ -1,25 +1,29 @@
 const interpark = {
   keyColor: "#d40000",
   hoverColor: "#b50000",
-  subColor: "#00ff50"
+  subColor: "#00ff50",
+  grayColor: "#2c2c2c"
 };
 
 const melonticket = {
   keyColor: "#00ff00",
   hoverColor: "#00b500",
-  subColor: "#00ff0050"
+  subColor: "#00ff0050",
+  grayColor: "#2c2c2c"
 };
 
 const ticketlink = {
   keyColor: "#00ff00",
   hoverColor: "#00b500",
-  subColor: "#00ff0050"
+  subColor: "#00ff0050",
+  grayColor: "#2c2c2c"
 };
 
 const yes24 = {
   keyColor: "#00a2ff",
   hoverColor: "#005bb5",
-  subColor: "#00a2ff50"
+  subColor: "#00a2ff50",
+  grayColor: "#2c2c2c"
 };
 
 const practice = {};

--- a/src/styles/theme.js
+++ b/src/styles/theme.js
@@ -1,75 +1,29 @@
-import "../index.css";
-
-const practice = {
-  "--sub-color": "#edeaf9",
-  "--key-color": "#472fd2",
-  "--hover-color": "#1d00c8",
-  /*point color*/
-  " --point-color": "#ff6347",
-  "--point-color2": "#ffbe17",
-  "--point-hover-color2": "#efb316",
-  /*gray scale*/
-  "--fill-color": "#cccccc",
-  "--text-color": "#666666",
-  "--text-color2": "#333333"
-};
 const interpark = {
-  "--sub-color": "#edeaf9",
-  "--key-color": "#000000",
-  "--hover-color": "#1d00c8",
-  /*point color*/
-  " --point-color": "#ff6347",
-  "--point-color2": "#ffbe17",
-  "--point-hover-color2": "#efb316",
-  /*gray scale*/
-  "--fill-color": "#cccccc",
-  "--text-color": "#666666",
-  "--text-color2": "#333333"
+  keyColor: "#d40000",
+  hoverColor: "#b50000",
+  subColor: "#00ff50"
 };
 
 const melonticket = {
-  "--sub-color": "#edeaf9",
-  "--key-color": "#472fd2",
-  "--hover-color": "#1d00c8",
-  /*point color*/
-  " --point-color": "#ff6347",
-  "--point-color2": "#ffbe17",
-  "--point-hover-color2": "#efb316",
-  /*gray scale*/
-  "--fill-color": "#cccccc",
-  "--text-color": "#666666",
-  "--text-color2": "#333333"
+  keyColor: "#00ff00",
+  hoverColor: "#00b500",
+  subColor: "#00ff0050"
 };
 
 const ticketlink = {
-  "--sub-color": "#edeaf9",
-  "--key-color": "#472fd2",
-  "--hover-color": "#1d00c8",
-  /*point color*/
-  " --point-color": "#ff6347",
-  "--point-color2": "#ffbe17",
-  "--point-hover-color2": "#efb316",
-  /*gray scale*/
-  "--fill-color": "#cccccc",
-  "--text-color": "#666666",
-  "--text-color2": "#333333"
+  keyColor: "#00ff00",
+  hoverColor: "#00b500",
+  subColor: "#00ff0050"
 };
 
 const yes24 = {
-  "--sub-color": "#edeaf9",
-  "--key-color": "#472fd2",
-  "--hover-color": "#1d00c8",
-  /*point color*/
-  " --point-color": "#ff6347",
-  "--point-color2": "#ffbe17",
-  "--point-hover-color2": "#efb316",
-  /*gray scale*/
-  "--fill-color": "#cccccc",
-  "--text-color": "#666666",
-  "--text-color2": "#333333"
+  keyColor: "#00a2ff",
+  hoverColor: "#005bb5",
+  subColor: "#00a2ff50"
 };
 
-// 내보내는 테마 객체
+const practice = {};
+
 const theme = {
   interpark,
   melonticket,

--- a/src/util/resetAtom.js
+++ b/src/util/resetAtom.js
@@ -7,6 +7,7 @@ const resetAtom = () => {
   sessionStorage.removeItem("seatCount");
   sessionStorage.removeItem("seatInfo");
   sessionStorage.removeItem("posterId");
+  sessionStorage.setItem("themeSite", "practice");
 };
 
 export default resetAtom;


### PR DESCRIPTION
# 📝작업 내용
- 버튼 컴포넌트 css 리팩토링
`Button.module.css`에 기본 타입과 아웃라인 타입만 css 추가해둠.
버튼 컴포넌트에서 theme를 atom으로 받아오고, 해당 사이트의 테마에 따라 buttonClass를 사용하여 스타일링 함. <= 여러가지 시도해봤는데 styled-components가 아니어서 모듈 css는 그냥 사이트별로 따로 이름짓고 클래스로 불러오는게 가장 간편했음..!
이렇게 구현한 이유: 프로그래스 바는 스타일드 컴포넌트를 사용했기 때문에 ThemeProvider를 사용하면 편리하지만, module css를 사용하는 버튼 같은 경우는 ThemeProvider 적용 시 더 복잡해지는 것 같았음.

- SelectRoundInterpark.jsx
실전모드 인터파크 임시 테스트 페이지
버튼 타입을 "outline"으로 설정하면 해당 테마에 맞는 색상이 module.css에서 적용됨

- 그 밖의 수정
  - 도움말 버튼이 실전모드에서는 렌더링되지 않도록 수정
  - 메인 페이지에서 세션스토리지에 저장된 themeSiteAtom를 reset하는 부분 추가
  -  사이트 선택, 인트로 페이지에서 기본 테마로 reset

## 스크린샷 (선택)
개발자 도구를 활용해 themeSite를 바꿔본 결과 제대로 동작함을 확인할 수 있음
![2024-08-17 13 42 17](https://github.com/user-attachments/assets/bada1df8-cc46-456a-a6bb-14c2c9d04150)
![2024-08-17 13 42 44](https://github.com/user-attachments/assets/1d2be96c-5f6b-43d7-8897-4c2a3e3a434f)

- 프로그래스바 색상 죽이기
![2024-08-17 13 35 21](https://github.com/user-attachments/assets/163b0ed1-8325-4310-af10-796fe61164f9)


## 💬리뷰 요구사항
ThemeProvider.jsx 파일에서 export가 중복으로 내보내져서 경고 발생하는데 분리하면 좋으려나.
모듈 css 관련 부분은 혹시 더 좋은 방법으로 리팩토링할 수 있는 아이디어가 있다면 알려줄래?
theme.js랑 버튼 모듈 css 색깔은 일단 임시로 지정해두었는데, 사이트 만들면서 자유롭게 수정하면 될 것 같아.