### PR TITLE
Refactor: theme 적용 전 UI 수정

### DIFF
--- a/src/components/Animation.jsx
+++ b/src/components/Animation.jsx
@@ -24,6 +24,7 @@ const AnimationArea = styled.div`
       animation: ${blink} 1.5s infinite;
     `}
   border-radius: 8px;
+  z-index: 500;
 `;
 
 export default AnimationArea;

--- a/src/components/ProgressBar.jsx
+++ b/src/components/ProgressBar.jsx
@@ -2,7 +2,6 @@ import React, { useEffect, useState } from "react";
 import styled from "styled-components";
 import { useAtomValue, useAtom } from "jotai";
 import { progressAtom, themeSiteAtom } from "../store/atom";
-import theme from "../styles/theme";
 
 const ProgressBarContainer = styled.div`
   display: flex;
@@ -19,14 +18,14 @@ const ProgressStep = styled.div`
   align-items: center;
 `;
 
-// 테마에 따라 색상을 반환하는 함수
-const getColor = (props, type) => {
-  const themeColors = theme[props.$themeSite] || theme.default;
-  if (props.$themeSite === "practice" || props.$themeSite === null) {
-    // 디폴트 테마(practice)이면 기본 키 컬러 적용
-    return "var(--key-color)";
-  } else return themeColors[type];
-};
+// // 테마에 따라 색상을 반환하는 함수
+// const getColor = (props, type) => {
+//   const themeColors = theme[props.$themeSite] || theme.default;
+//   if (props.$themeSite === "practice" || props.$themeSite === null) {
+//     // 디폴트 테마(practice)이면 기본 키 컬러 적용
+//     return "var(--key-color)";
+//   } else return themeColors[type];
+// };
 
 const StepNumber = styled.div`
   display: flex;
@@ -36,7 +35,7 @@ const StepNumber = styled.div`
   height: 30px;
   border-radius: 50%;
   background-color: ${(props) =>
-    props.$active ? getColor(props, "grayColor") : "var(--fill-color)"};
+    props.$active ? "var(--progress-color)" : "var(--fill-color)"};
   color: #fff;
   margin-bottom: 10px;
   font-family: "pretendardB";
@@ -46,7 +45,7 @@ const StepLine = styled.div`
   width: 211px;
   height: 13px;
   background-color: ${(props) =>
-    props.$active ? getColor(props, "grayColor") : "var(--fill-color)"};
+    props.$active ? "var(--progress-color)" : "var(--fill-color)"};
   margin-bottom: 10px;
 
   &.rounded-start {
@@ -60,7 +59,7 @@ const StepLine = styled.div`
 const StepLabel = styled.div`
   font-size: 20px;
   color: ${(props) =>
-    props.$active ? getColor(props, "grayColor") : "var(--text-color)"};
+    props.$active ? "var(--key-color)" : "var(--text-color)"};
   text-align: center;
   font-family: "pretendardB";
   white-space: nowrap;

--- a/src/components/SeatCount.jsx
+++ b/src/components/SeatCount.jsx
@@ -5,7 +5,7 @@ import { useAtom, useAtomValue } from "jotai";
 import Animation from "./Animation";
 
 const SeatCountContainer = styled.div`
-  border: 1px solid var(--key-color);
+  border: 2px solid var(--fill-color);
   border-radius: 8px;
   padding: 20px;
   padding-bottom: 10px;
@@ -32,7 +32,10 @@ const InfoRow = styled.div`
 const InfoText = styled.div`
   color: var(--text-color);
 `;
-
+const Price = styled.span`
+  color: var(--key-color);
+  font-family: "pretendardB";
+`;
 const CountSelector = styled.select`
   width: 70px;
   height: 30px;
@@ -75,7 +78,7 @@ const SeatCount = () => {
       <InfoRow>
         <InfoText>기본가</InfoText>
         <InfoText>일반</InfoText>
-        <InfoText>{seatInfo.price}원</InfoText>
+        <Price>{seatInfo.price}원</Price>
         <Animation $focus={focus}>
           <CountSelector
             $focus={focus}

--- a/src/components/button/Button.module.css
+++ b/src/components/button/Button.module.css
@@ -9,7 +9,7 @@
   border-radius: 4px;
   justify-content: center;
   align-items: center;
-  font-family: "pretendardR";
+  font-family: "pretendardB";
   font-size: 16px;
   font-style: normal;
   background-color: var(--key-color);
@@ -23,13 +23,13 @@
 
 /*이전 단계*/
 .button--prev {
-  background-color: var(--sub-color);
-  border: 1px solid var(--key-color);
+  background-color: #fff;
+  border: 2px solid var(--key-color);
   color: var(--key-color);
 }
 .button--prev:hover {
   background-color: var(--sub-color);
-  border: 1px solid var(--key-color);
+  border: 2px solid var(--key-color);
   color: var(--key-color);
 }
 /* 좌석 선택 */

--- a/src/components/calender/calenderStyles.js
+++ b/src/components/calender/calenderStyles.js
@@ -37,12 +37,12 @@ export const StyledCalendarWrapper = styled.div`
     font-size: 30px;
     &:nth-child(1),
     &:nth-child(3) {
-      color: var(--key-color);
+      color: var(--fill-color);
       font-family: "pretendardR";
     }
     &:nth-child(1):hover,
     &:nth-child(3):hover {
-      color: var(--key-color);
+      color: var(--fill-color);
     }
     &:hover {
       background: none;

--- a/src/components/forms/ticket/TicketBuyer.jsx
+++ b/src/components/forms/ticket/TicketBuyer.jsx
@@ -1,7 +1,6 @@
 import styled from "styled-components";
 import { FormWrap } from "../FormStyle";
 import { InputContainer, Label } from "../../input/InputStyle";
-import { useForm } from "../../../hooks/useForm";
 import { useAtomValue } from "jotai";
 import { levelAtom } from "../../../store/atom";
 import { useState } from "react";
@@ -13,6 +12,10 @@ const BuyerWrap = styled.div`
 
 const BuyerContainer = styled(FormWrap)`
   gap: 10px;
+`;
+
+const BuyerLabel = styled(Label)`
+  color: var(--text-color);
 `;
 
 const InfoBox = styled.div`
@@ -82,7 +85,7 @@ const TicketBuyer = ({ option, setIsValidate, errorArray }) => {
         <BuyerContainer>
           {data_essential.map((item, index) => (
             <InputContainer key={index}>
-              <Label>{item.label}</Label>
+              <BuyerLabel>{item.label}</BuyerLabel>
               {level === "high" && item.label === "생년월일" ? (
                 <InfoInput
                   name="birth"

--- a/src/components/forms/ticket/TicketMethod.jsx
+++ b/src/components/forms/ticket/TicketMethod.jsx
@@ -15,7 +15,7 @@ const TicketMethodCont = styled.div`
   color: ${(props) => props.$hasError && "var(--point-color)"};
 `;
 const TicketMethodWrap = styled(FormWrap)`
-  border: 1px solid var(--key-color);
+  border: 2px solid var(--fill-color);
   border-radius: 8px;
   display: inline-flex;
   flex-direction: column;

--- a/src/components/header/Header.jsx
+++ b/src/components/header/Header.jsx
@@ -11,7 +11,6 @@ const HeaderContainer = styled.div`
   position: relative;
 `;
 
-//로고로 대치 예정
 const LogoContainer = styled.div`
   width: 140px;
   height: 80px;

--- a/src/components/header/nav/Nav.jsx
+++ b/src/components/header/nav/Nav.jsx
@@ -39,8 +39,10 @@ const NavContent = styled.li`
   //조건부 css : 마우스 hover 네비게이터는 서브네비게이터가 사라지기 전까지 css 유지
   //1) 현재 sideNavigator 영역까지 포함됐을 때 hovered상태인가?
   //2) 해당 navigator가 hovered상태인가?
-  color: ${({ $ishovered, $isactive }) =>
-    $ishovered && $isactive ? "var(--key-color)" : "var(--text-color)"};
+  color: ${(props) =>
+    props.$ishovered && props.$isactive
+      ? props.theme.default.keyColor
+      : "var(--text-color)"};
 
   &::after {
     content: "";
@@ -49,7 +51,7 @@ const NavContent = styled.li`
     left: 0;
     width: 120px;
     height: 0;
-    background-color: var(--key-color);
+    background-color: ${(props) => props.theme.default.keyColor};
     border-radius: 50px;
     transition: height 0.1s ease;
     ${({ $isactive, $ishovered }) =>

--- a/src/components/header/nav/subNav/SubNav.jsx
+++ b/src/components/header/nav/subNav/SubNav.jsx
@@ -2,10 +2,11 @@ import styled from "styled-components";
 import { useNavigate } from "react-router-dom";
 import { levelAtom, themeSiteAtom } from "../../../../store/atom";
 import { useSetAtom } from "jotai";
+
 const SubNavWrap = styled.div`
   width: 1320px;
   height: 50px;
-  background-color: var(--sub-color);
+  background-color: ${(props) => props.theme.default.subColor};
   display: flex;
   justify-content: center;
 `;

--- a/src/components/myBookingInfo/MyBookingInfo.jsx
+++ b/src/components/myBookingInfo/MyBookingInfo.jsx
@@ -10,10 +10,9 @@ import {
 import { useAtomValue } from "jotai";
 import { useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
-import { useForm } from "../../hooks/useForm";
 
 const Container = styled.div`
-  border: 1px solid var(--key-color);
+  border: 2px solid var(--fill-color);
   border-radius: 8px;
   width: 400px;
   height: 457px;
@@ -47,7 +46,7 @@ const TotalAmount = styled.div`
   margin: 0 20px 0 20px;
   display: flex;
   justify-content: space-between;
-  border-top: 1px solid var(--key-color);
+  border-top: 2px solid var(--fill-color);
 `;
 
 const AmountTitle = styled.div`

--- a/src/components/myBookingInfo/MyBookingInfo.jsx
+++ b/src/components/myBookingInfo/MyBookingInfo.jsx
@@ -61,7 +61,6 @@ const AmountContent = styled.div`
   font-family: pretendardB;
   font-size: 28px;
   margin-top: 20px;
-  color: var(--key-color);
 `;
 const ButtonContainer = styled.div`
   display: flex;

--- a/src/components/myBookingInfo/MyBookingInfo.jsx
+++ b/src/components/myBookingInfo/MyBookingInfo.jsx
@@ -31,12 +31,16 @@ const InfoContainer = styled.div`
   display: flex;
   flex-direction: column;
   margin: 20px 20px 0 20px;
-  font-family: "pretendardR";
 `;
 const InfoItem = styled.div`
   display: flex;
   justify-content: space-between;
   margin: 10px 0;
+`;
+const InfoTitle = styled.span`
+  color: var(--text-color);
+  font-family: "pretendardB";
+  font-size: 16px;
 `;
 const InfoText = styled.div`
   font-family: "pretendardB";
@@ -57,6 +61,7 @@ const AmountContent = styled.div`
   font-family: pretendardB;
   font-size: 28px;
   margin-top: 20px;
+  color: var(--key-color);
 `;
 const ButtonContainer = styled.div`
   display: flex;
@@ -147,7 +152,7 @@ const MyBookingInfo = ({
       <InfoContainer>
         {Info.map((item, index) => (
           <InfoItem key={index}>
-            <InfoText>{item.title}</InfoText>
+            <InfoTitle>{item.title}</InfoTitle>
             <InfoText>
               {item.price != undefined ? item.price + "원" : item.content}
             </InfoText>

--- a/src/components/poster/PosterList.jsx
+++ b/src/components/poster/PosterList.jsx
@@ -58,19 +58,17 @@ const PosterContainer = styled.div`
   width: 240px;
   height: 470px;
   border-radius: 8px;
-  background-color: var(--sub-color);
+  background-color: var(--fill-color);
   padding: 4px 2px;
   box-shadow: 0 4px 8px rgba(0, 0, 0, 0.2);
 
   /* hover 시 색상 적절히 변하도록 css 적용 */
   &:hover {
     box-shadow: 0 8px 16px rgba(0, 0, 0, 0.5);
-    background-color: var(--key-color);
-    color: white;
+    background-color: var(--sub-color);
   }
 
   &:hover ${PosterTitle}, &:hover ${PosterVenue}, &:hover ${PosterTime} {
-    color: white;
   }
 `;
 

--- a/src/components/seatChart/SeatChart.jsx
+++ b/src/components/seatChart/SeatChart.jsx
@@ -16,7 +16,7 @@ const Stage = styled.div`
   display: flex;
   width: 400px;
   min-height: 70px;
-  border: 1px solid var(--key-color);
+  border: 2px solid var(--fill-color);
   border-radius: 4px;
   margin: 5px;
   align-items: center;
@@ -35,7 +35,7 @@ const SeatGridContainer = styled.div`
 const SeatChart = () => {
   return (
     <SeatChartContainer>
-      <Stage>스테이지</Stage>
+      <Stage>무대</Stage>
       <SeatGridContainer>
         {/* SeatGrid 4개 배치 */}
         {[0, 1, 2, 3].map((gridIndex) => (

--- a/src/components/seatChart/seatGrid/Seat.jsx
+++ b/src/components/seatChart/seatGrid/Seat.jsx
@@ -5,13 +5,13 @@ import AnimationArea from "../../Animation";
 const SeatDiv = styled.div`
   width: 20px;
   height: 20px;
-  border: 1px solid var(--key-color);
   border-radius: 4px;
-  background-color: ${(props) => props.$isallowed && "var(--key-color)"};
+  background-color: ${(props) =>
+    props.$isallowed ? "var(--key-color)" : "var(--fill-color)"};
   cursor: ${(props) => props.$isallowed && "pointer"};
 `;
 const SeatAnimationArea = styled(AnimationArea)`
-  padding: 5px;
+  padding: 3px;
 `;
 const Seat = ({ isallowed }) => {
   const level = useAtomValue(levelAtom);

--- a/src/components/seatInfo/SeatInfo.jsx
+++ b/src/components/seatInfo/SeatInfo.jsx
@@ -4,7 +4,6 @@ import {
   isSeatSelectedAtom,
   allowedSeatAtom,
   levelAtom,
-  allowedSectionAtom,
   postersAtom,
   selectedPosterAtom,
   seatInfoAtom
@@ -18,6 +17,7 @@ import {
   SelectedSeatsHeader,
   SelectedSeatsInfo,
   SeatGrade,
+  SeatInfoCont,
   SeatPrice,
   ButtonAnimationArea
 } from "./SeatInfoStyles";
@@ -79,11 +79,11 @@ const SeatInfo = () => {
       <SelectedSeats>
         <SelectedSeatsInfo>
           <SeatGrade>좌석등급</SeatGrade>
-          <SeatPrice>좌석정보</SeatPrice>
+          <SeatGrade>좌석정보</SeatGrade>
           {isSeatSelected && (
             <>
-              <SeatGrade>{seatInfo.grade}</SeatGrade>
-              <SeatPrice>{`${allowedSeat.row + 1}열-${allowedSeat.col + 1}`}</SeatPrice>
+              <SeatInfoCont>{seatInfo.grade}</SeatInfoCont>
+              <SeatInfoCont>{`${allowedSeat.row + 1}열-${allowedSeat.col + 1}`}</SeatInfoCont>
             </>
           )}
         </SelectedSeatsInfo>

--- a/src/components/seatInfo/SeatInfoStyles.jsx
+++ b/src/components/seatInfo/SeatInfoStyles.jsx
@@ -6,9 +6,9 @@ export const SeatInfoContainer = styled.div`
   flex-direction: column;
   justify-content: space-between;
   align-items: center;
-  border: 1px solid var(--key-color);
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.05);
   border-radius: 8px;
-  padding: 8px;
+  padding: 20px;
   width: 300px;
   height: 480px;
 `;
@@ -23,9 +23,9 @@ export const Header = styled.span`
 `;
 
 export const SeatTableContainer = styled.div`
-  border: 1px solid var(--key-color);
+  border: 1px solid var(--fill-color);
   border-radius: 8px;
-  padding: 16px 8px;
+  padding: 16px 16px;
   width: 265px;
   height: 110px;
   display: flex;
@@ -39,9 +39,9 @@ export const SeatTableDiv = styled.div`
 `;
 
 export const SelectedSeats = styled.div`
-  border: 1px solid var(--key-color);
+  border: 1px solid var(--fill-color);
   border-radius: 8px;
-  padding: 8px;
+  padding: 16px;
   width: 265px;
   height: 140px;
 `;
@@ -57,14 +57,19 @@ export const SelectedSeatsInfo = styled.div`
 `;
 
 export const SeatGrade = styled.span`
-  font-family: "pretendardM";
+  color: var(--text-color);
   font-size: 14px;
   margin: 0 24px 8px 0;
 `;
 
 export const SeatPrice = styled.span`
-  font-family: "pretendardM";
+  color: var(--text-color2);
   font-size: 14px;
+`;
+export const SeatInfoCont = styled.span`
+  font-family: "pretendardB";
+  font-size: 14px;
+  color: var(--key-color);
 `;
 
 export const ButtonAnimationArea = styled(AnimationArea)`

--- a/src/components/seatSection/SeatSection.jsx
+++ b/src/components/seatSection/SeatSection.jsx
@@ -18,7 +18,7 @@ const Stage = styled.div`
   justify-content: center;
   align-items: center;
   font-size: 20px;
-  border: 1px solid var(--key-color);
+  border: 2px solid var(--fill-color);
   border-radius: 4px;
 `;
 const Sections = styled.div`

--- a/src/components/seatSection/section/Section.jsx
+++ b/src/components/seatSection/section/Section.jsx
@@ -8,12 +8,18 @@ import {
 } from "../../../store/atom";
 
 const SectionDiv = styled.div`
-  border: 1px solid var(--key-color);
+  border: 2px solid var(--fill-color);
   border-radius: 4px;
   width: 200px;
   height: 150px;
-  cursor: ${(props) => props.$cursor && "pointer"};
+  cursor: pointer;
   margin: ${(props) => !props.$cursor && "3px"};
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  &:hover {
+    border: 2px solid var(--text-color);
+  }
 `;
 const Section = ({ num }) => {
   const allowedSection = useAtomValue(allowedSectionAtom);

--- a/src/index.css
+++ b/src/index.css
@@ -19,6 +19,7 @@
   --sub-color: #edeaf9;
   --key-color: #472fd2;
   --hover-color: #1d00c8;
+  --progress-color: #9a8ce5;
 
   /*point color*/
   --point-color: #ff6347;
@@ -33,21 +34,25 @@
   --key-color-interpark: #d40000;
   --hover-color-interpark: #b50000;
   --sub-color-interpark: #ffdada;
+  --progress-color-interpark: #d47373;
   --gray-color-interpark: #2c2c2c;
 
   --key-color-melonticket: #00cd3c;
   --hover-color-melonticket: #00b500;
   --sub-color-melonticket: #d1ffd1;
+  --progress-color-melonticket: #3d8553;
   --gray-color-melonticket: #2c2c2c;
 
   --key-color-ticketlink: #ff1c1c;
   --hover-color-ticketlink: #b50000;
   --sub-color-ticketlink: #ffcfcf;
+  --progress-color-ticketlink: #c7bd4f;
   --gray-color-ticketlink: #2c2c2c;
 
   --key-color-yes24: #00a2ff;
   --hover-color-yes24: #005bb5;
   --sub-color-yes24: #def3ff;
+  --progress-color-yes24: #241e94;
   --gray-color-yes24: #2c2c2c;
 }
 /* Interpark 테마 */
@@ -56,6 +61,7 @@
   --hover-color: var(--hover-color-interpark);
   --sub-color: var(--sub-color-interpark);
   --gray-color: var(--gray-color-interpark);
+  --progress-color: var(--progress-color-interpark);
 }
 
 /* Melonticket 테마 */
@@ -64,6 +70,7 @@
   --hover-color: var(--hover-color-melonticket);
   --sub-color: var(--sub-color-melonticket);
   --gray-color: var(--gray-color-melonticket);
+  --progress-color: var(--progress-color-melonticket);
 }
 
 /* Ticketlink 테마 */
@@ -72,6 +79,7 @@
   --hover-color: var(--hover-color-ticketlink);
   --sub-color: var(--sub-color-ticketlink);
   --gray-color: var(--gray-color-ticketlink);
+  --progress-color: var(--progress-color-ticketlink);
 }
 
 /* Yes24 테마 */
@@ -80,6 +88,7 @@
   --hover-color: var(--hover-color-yes24);
   --sub-color: var(--sub-color-yes24);
   --gray-color: var(--gray-color-yes24);
+  --progress-color: var(--progress-color-yes24);
 }
 /*default setting*/
 body {

--- a/src/index.css
+++ b/src/index.css
@@ -32,22 +32,22 @@
 
   --key-color-interpark: #d40000;
   --hover-color-interpark: #b50000;
-  --sub-color-interpark: #00ff50;
+  --sub-color-interpark: #ffdada;
   --gray-color-interpark: #2c2c2c;
 
   --key-color-melonticket: #00cd3c;
   --hover-color-melonticket: #00b500;
-  --sub-color-melonticket: #00ff0050;
+  --sub-color-melonticket: #d1ffd1;
   --gray-color-melonticket: #2c2c2c;
 
-  --key-color-ticketlink: #00ff00;
-  --hover-color-ticketlink: #00b500;
-  --sub-color-ticketlink: #00ff0050;
+  --key-color-ticketlink: #ff1c1c;
+  --hover-color-ticketlink: #b50000;
+  --sub-color-ticketlink: #ffcfcf;
   --gray-color-ticketlink: #2c2c2c;
 
   --key-color-yes24: #00a2ff;
   --hover-color-yes24: #005bb5;
-  --sub-color-yes24: #00a2ff50;
+  --sub-color-yes24: #def3ff;
   --gray-color-yes24: #2c2c2c;
 }
 /* Interpark 테마 */

--- a/src/pages/ProgressContents.jsx
+++ b/src/pages/ProgressContents.jsx
@@ -52,7 +52,7 @@ const ProgressContents = ({ text }) => {
   //레벨 별 타이머 출력 설정
   const level = useAtomValue(levelAtom);
   const [isModalOpen, setIsModalOpen] = useState(false);
-  const theme = useAtomValue(themeSiteAtom);
+  const themeSite = useAtomValue(themeSiteAtom);
 
   const handleModalOpen = () => {
     setIsModalOpen(true);
@@ -62,8 +62,8 @@ const ProgressContents = ({ text }) => {
     setIsModalOpen(false);
   };
 
-  // 실전 모드인 경우(테마 정보가 있는 경우) 도움말 버튼 숨기기
-  const showHelpButton = !theme;
+  // 연습모드인 경우만 도움말 버튼 보여주기
+  const showHelpButton = themeSite === "practice";
 
   return (
     <ProgressContentsContainer>

--- a/src/pages/challengeMode/step0/ChallangeIntro.jsx
+++ b/src/pages/challengeMode/step0/ChallangeIntro.jsx
@@ -1,0 +1,55 @@
+import React, { useEffect } from "react";
+import styled from "styled-components";
+import { useNavigate } from "react-router-dom";
+import { useAtom, useSetAtom } from "jotai";
+import { progressAtom, themeSiteAtom } from "../../../store/atom";
+import Button from "../../../components/button/Button";
+import AnimationArea from "../../../components/Animation";
+import ChallangeIntroMessage from "./introMessage/ChallangeIntroMessage";
+
+const IntroContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  height: 100%;
+`;
+
+const ChallangeIntro = () => {
+  const navigate = useNavigate();
+  const [progress, setProgress] = useAtom(progressAtom);
+  const [themeSite] = useAtom(themeSiteAtom);
+
+  useEffect(() => {
+    setProgress(0);
+  }, [setProgress]);
+
+  const handleClick = () => {
+    setProgress(1);
+    switch (themeSite) {
+      case "interpark":
+        navigate("/interpark/step1-1");
+        break;
+      case "melonticket":
+        navigate("/melonticket/step1-1");
+        break;
+      case "ticketlink":
+        navigate("/ticketlink/step1-1");
+        break;
+      case "yes24":
+        navigate("/yes24/step1-1");
+        break;
+    }
+  };
+
+  return (
+    <IntroContainer>
+      <ChallangeIntroMessage />
+      <AnimationArea>
+        <Button text="시작하기" onClick={handleClick} />
+      </AnimationArea>
+    </IntroContainer>
+  );
+};
+
+export default ChallangeIntro;

--- a/src/pages/challengeMode/step0/introMessage/ChallangeIntroMessage.jsx
+++ b/src/pages/challengeMode/step0/introMessage/ChallangeIntroMessage.jsx
@@ -1,0 +1,32 @@
+import React from "react";
+import { useAtomValue } from "jotai";
+import { themeSiteAtom } from "../../../../store/atom";
+import {
+  InterparkText,
+  MelonTicketText,
+  TicketLinkText,
+  Yes24Text
+} from "../introMessage/introText/IntroText";
+
+const ChallangeIntroMessage = () => {
+  const themeSite = useAtomValue(themeSiteAtom);
+
+  const renderMessage = () => {
+    switch (themeSite) {
+      case "interpark":
+        return <InterparkText />;
+      case "melonticket":
+        return <MelonTicketText />;
+      case "ticketlink":
+        return <TicketLinkText />;
+      case "yes24":
+        return <Yes24Text />;
+      default:
+        return null;
+    }
+  };
+
+  return <>{renderMessage()}</>;
+};
+
+export default ChallangeIntroMessage;

--- a/src/pages/challengeMode/step0/introMessage/introText/IntroText.css
+++ b/src/pages/challengeMode/step0/introMessage/introText/IntroText.css
@@ -1,0 +1,3 @@
+.key-color {
+  color: var(--key-color);
+}

--- a/src/pages/challengeMode/step0/introMessage/introText/IntroText.jsx
+++ b/src/pages/challengeMode/step0/introMessage/introText/IntroText.jsx
@@ -1,0 +1,61 @@
+import React from "react";
+import styled from "styled-components";
+import "./IntroText.css";
+
+const Title = styled.div`
+  font-size: 40px;
+  font-style: normal;
+  letter-spacing: -2.5px;
+  text-align: center;
+  line-height: normal;
+  margin-bottom: 30px;
+`;
+
+const Main = styled.div`
+  text-align: center;
+  font-size: 25px;
+  font-style: normal;
+  letter-spacing: -1.5px;
+  line-height: normal;
+  margin-bottom: 30px;
+`;
+
+export const InterparkText = () => (
+  <>
+    <Title>인터파크 티켓</Title>
+    <Main>
+      <p>제한 시간 내에 티켓 예매를 완료해보세요.</p>
+      <p>잠시 쉬고 싶다면 ESC 키를 누르세요.</p>
+    </Main>
+  </>
+);
+
+export const MelonTicketText = () => (
+  <>
+    <Title>멜론티켓</Title>
+    <Main>
+      <p>제한 시간 내에 티켓 예매를 완료해보세요.</p>
+      <p>잠시 쉬고 싶다면 ESC 키를 누르세요.</p>
+    </Main>
+  </>
+);
+
+export const TicketLinkText = () => (
+  <>
+    <Title>티켓링크</Title>
+    <Main>
+      <p>제한 시간 내에 티켓 예매를 완료해보세요.</p>
+      <p>잠시 쉬고 싶다면 ESC 키를 누르세요.</p>
+    </Main>
+  </>
+);
+
+export const Yes24Text = () => (
+  <>
+    <Title>YES24</Title>
+    <Main>
+      <p>제한 시간 내에 티켓 예매를 완료해보세요.</p>
+      <p>잠시 쉬고 싶다면 ESC 키를 누르세요.</p>
+    </Main>
+  </>
+);

--- a/src/pages/practiceMode/selectSite/selectSite.jsx
+++ b/src/pages/practiceMode/selectSite/selectSite.jsx
@@ -40,10 +40,7 @@ const SelectSite = () => {
   const setThemeSite = useSetAtom(themeSiteAtom);
 
   useEffect(() => {
-    // 사이트 선택 시 default 테마를 적용
-    if (window.location.pathname === "/select-site") {
-      setThemeSite(null);
-    }
+    setThemeSite(null);
   }, [setThemeSite]);
 
   const sites = [

--- a/src/pages/practiceMode/step2/SelectSeat.jsx
+++ b/src/pages/practiceMode/step2/SelectSeat.jsx
@@ -9,6 +9,7 @@ const SelectSeatcontainer = styled.div`
   display: flex;
   justify-content: space-evenly;
   align-items: center;
+  gap: 80px;
 `;
 const SelectSeat = () => {
   const isSectionSelected = useAtomValue(isSectionSelectedAtom);

--- a/src/pages/practiceMode/step5/Step5.jsx
+++ b/src/pages/practiceMode/step5/Step5.jsx
@@ -1,10 +1,10 @@
 import React, { useEffect } from "react";
 import styled from "styled-components";
 import Button from "../../../components/button/Button";
-import { useAtom } from "jotai";
-import { levelAtom, progressAtom } from "../../../store/atom";
+import { useAtom, useSetAtom } from "jotai";
+import { levelAtom, progressAtom, themeSiteAtom } from "../../../store/atom";
 import { useNavigate } from "react-router-dom";
-import useResetAtom from "../../../util/resetAtom";
+
 const Step5Container = styled.div`
   display: flex;
   flex-direction: column;
@@ -46,11 +46,15 @@ const Step5 = () => {
   const [, setProgress] = useAtom(progressAtom);
   const navigate = useNavigate();
 
+  const setThemeSite = useSetAtom(themeSiteAtom);
+
+  useEffect(() => {
+    setThemeSite(null);
+  }, [setThemeSite]);
+
   useEffect(() => {
     setProgress(5);
   }, [setProgress]);
-
-  // useResetAtom();
 
   // 난이도 선택 창으로
   const handlePracticeModeClick = () => {

--- a/src/routes.jsx
+++ b/src/routes.jsx
@@ -16,6 +16,7 @@ import Step5 from "./pages/practiceMode/step5/Step5";
 import SelectSeat from "./pages/practiceMode/step2/SelectSeat";
 import SeatPriceCheck from "./pages/practiceMode/step3/SeatPriceCheck";
 import PrivateRoute from "./pages/PrivateRoute";
+import ChallangeIntro from "./pages/challengeMode/step0/ChallangeIntro";
 
 const router = createBrowserRouter([
   {
@@ -76,6 +77,11 @@ const router = createBrowserRouter([
         path: "interpark",
         element: <ProgressContents />,
         children: [
+          {
+            path: "step0",
+            element: <PrivateRoute element={<ChallangeIntro />} />,
+            label: "인트로"
+          },
           {
             path: "step1",
             element: <PrivateRoute element={<SelectRoundInterpark />} />,

--- a/src/styles/theme.js
+++ b/src/styles/theme.js
@@ -1,40 +1,10 @@
-const interpark = {
-  keyColor: "var(--key-color)",
-  subColor: "var(--sub-color)",
-  grayColor: "var(--gray-color-interpark)"
-};
-
-const melonticket = {
-  keyColor: "var(--key-color)",
-  subColor: "var(--sub-color)",
-  grayColor: "var(--gray-color-melonticket)"
-};
-
-const ticketlink = {
-  keyColor: "var(--key-color)",
-  subColor: "var(--sub-color)",
-  grayColor: "var(--gray-color-ticketlink)"
-};
-
-const yes24 = {
-  keyColor: "var(--key-color)",
-  subColor: "var(--sub-color)",
-  grayColor: "var(--gray-color-yes24)"
-};
-
-const practice = {
-  keyColor: "var(--key-color)",
-  hoverColor: "var(--hover-color)",
-  subColor: "var(--sub-color)",
-  grayColor: "var(--gray-color)"
-};
-
-const theme = {
-  interpark,
-  melonticket,
-  ticketlink,
-  yes24,
-  default: practice
+export const theme = {
+  //keyColor, subColor는 기존 practice mode의 --key-color와 --subZ
+  default: {
+    keyColor: "#472fd2",
+    subColor: "#edeaf9",
+    grayColor: "var(--gray-color-interpark)"
+  }
 };
 
 export default theme;

--- a/src/styles/theme.js
+++ b/src/styles/theme.js
@@ -1,28 +1,24 @@
 const interpark = {
-  keyColor: "var(--key-color-interpark)",
-  hoverColor: "var(--hover-color-interpark)",
-  subColor: "var(--sub-color-interpark)",
+  keyColor: "var(--key-color)",
+  subColor: "var(--sub-color)",
   grayColor: "var(--gray-color-interpark)"
 };
 
 const melonticket = {
-  keyColor: "var(--key-color-melonticket)",
-  hoverColor: "var(--hover-color-melonticket)",
-  subColor: "var(--sub-color-melonticket)",
+  keyColor: "var(--key-color)",
+  subColor: "var(--sub-color)",
   grayColor: "var(--gray-color-melonticket)"
 };
 
 const ticketlink = {
-  keyColor: "var(--key-color-ticketlink)",
-  hoverColor: "var(--hover-color-ticketlink)",
-  subColor: "var(--sub-color-ticketlink)",
+  keyColor: "var(--key-color)",
+  subColor: "var(--sub-color)",
   grayColor: "var(--gray-color-ticketlink)"
 };
 
 const yes24 = {
-  keyColor: "var(--key-color-yes24)",
-  hoverColor: "var(--hover-color-yes24)",
-  subColor: "var(--sub-color-yes24)",
+  keyColor: "var(--key-color)",
+  subColor: "var(--sub-color)",
   grayColor: "var(--gray-color-yes24)"
 };
 


### PR DESCRIPTION
## 📝작업 내용

### ✅ theme 적용 전 UI 수정
<img src ='https://github.com/user-attachments/assets/b5125108-28eb-4436-a028-31ada16761b4' width='500px'/> <br><br>

* 컴포넌트 border 색  gray scale로 변경
* 사용자 눈에 띄어야 하는 부분 (선택한 좌석이 어디인지, 가격은 얼마인지 등은 key color로 강조하고, 그 외에 단순한 input label이나 폼에서 중요하지 않은 부분은 폰트 컬러를 text color로 죽임

### ✅ThemeProvider 설정
**1) ProgressBar에선 ThemeProvider를 사용하고 있지 않았음**
* atom에 설정된 themeSite를 theme.js에 매개변수로 넣어서 색상코드를 가져오고 있음, ThemeProvider를 사용하고 있는 것이 아니었음
* 어차피 var() 변수를 쓸 거라면 ThemeProvider를 사용하지 않아도됨, getColor함수와 theme을 빼고 var() 변수로 참조하게끔 변경함

**2) Header 본 색상으로 설정**
* theme.js 파일에 오류 : 현재 var() 변수로 적용되는 색상들은 index.css를 따라감. index.css는 현재 CustomThemeProvider에 의해 팔레트가 제외되거나 넣어지고 있는 상태, var(--key-color) 를 사용하면 해당 themeSite의 key color가 적용되는 것이지 :root에 있는 key color가 적용되는 것이 아님
* 즉, theme.js는 index.css의 css 팔레트를 따라가지 않는 예외적인 색상들을  **색상코드 로 직접 정의**해 줘야 함 (var변수 쓰면 안됨)
* 이미 적혀있던 사이트별 key color, sub color, gray color는 index.css에 있음, var 변수로도 충분히 참조 가능. 굳이 theme.js에서 다시 정의해줄 필요가 없음, 삭제 후 index.css 적용에서 예외되는 색상들인 연습모드의 keycolor와 subcolor 등을 넣어줌

### 결론 : 기본적으로 index.css에 있는 css 팔레트를 따라가나, 예외적인 색상들은 theme.js로 컨트롤 해야 함, 이때 var() 변수는 index.css의 색상을 참고하므로 theme.js에서는 var변수를 사용하면 안됨. index.css에서 종속을 갖는  순간 예외 색상 처리가 불가능해짐!!

## 💬리뷰 요구사항
* border에서 key color를 사용하지 않다보니 강조되어야 하는 정보가 강조되지 않은 부분이 있는 것 같아서 색깔 정도만 가볍게 수정
* SeatInfo의 테두리는 일부러 없앰 border가 너무 많이 중첩돼있어서 고민하다가, 이미 소제목과 사용자에게 보여줄 컨텐츠 / 좌측의 좌석이 명확하게 분리돼있어서 한 번 더 감싸줄 필요가 없지 않을까 싶어 과감하게 뺌