### PR TITLE
Fix: themeSite 새로고침 오류 해결

### DIFF
--- a/src/components/ProgressBar.jsx
+++ b/src/components/ProgressBar.jsx
@@ -79,20 +79,6 @@ const Loading = styled.div`
 const ProgressBar = () => {
   const progress = useAtomValue(progressAtom);
   const [themeSite, setThemeSite] = useAtom(themeSiteAtom);
-  const [isLoading, setIsLoading] = useState(true);
-
-  useEffect(() => {
-    const fetchTheme = () => {
-      const storedTheme = sessionStorage.getItem("themeSite");
-      if (storedTheme) {
-        setThemeSite(storedTheme);
-      } else {
-        setThemeSite("practice");
-      }
-      setIsLoading(false);
-    };
-    fetchTheme();
-  }, [setThemeSite]);
 
   const steps = [
     "공연 및 회차선택",

--- a/src/pages/PrivateRoute.jsx
+++ b/src/pages/PrivateRoute.jsx
@@ -3,9 +3,14 @@ import { Navigate } from "react-router-dom";
 
 const PrivateRoute = ({ element }) => {
   //로컬 스토리지에 이름과 난이도가 설정되지 않았다면 메인 화면으로 이동
-  const isUser = sessionStorage.getItem("name");
+  const isUser = sessionStorage.getItem("userName");
   const isSelectedLevel = sessionStorage.getItem("level");
-  return isUser || isSelectedLevel ? element : <Navigate to="/" />;
+  const isSelectedSite = sessionStorage.getItem("themeSite");
+  return isUser && (isSelectedLevel || isSelectedSite) ? (
+    element
+  ) : (
+    <Navigate to="/" />
+  );
 };
 
 export default PrivateRoute;

--- a/src/pages/ProgressContents.jsx
+++ b/src/pages/ProgressContents.jsx
@@ -53,6 +53,7 @@ const ProgressContents = ({ text }) => {
   const level = useAtomValue(levelAtom);
   //도움말 모달창 제어
   const [isModalOpen, setIsModalOpen] = useState(false);
+  //theme
   const themeSite = useAtomValue(themeSiteAtom);
 
   const handleModalOpen = () => {
@@ -91,7 +92,7 @@ const ProgressContents = ({ text }) => {
       </ProgressBarBox>
       {/*고급 level일 경우에만 Timer 설정 */}
       {/*모달이 열렸을 경우 Timer 정지*/}
-      {level === "high" && (
+      {level === "high" && themeSite === "practice" && (
         <Timer
           type={"minute"}
           second={1000}

--- a/src/pages/ProgressContents.jsx
+++ b/src/pages/ProgressContents.jsx
@@ -68,7 +68,12 @@ const ProgressContents = ({ text }) => {
   const path = useLocation().pathname;
   const [isPaused, setIsPaused] = useState(false);
   const handlePaused = (e) => {
-    if (path !== "/progress/step0" && (e.key === "Escape" || e.key === "esc")) {
+    if (
+      //연습모드 step0 또는 실전모드 step0에서 렌더링되지 않도록 설정
+      path !== "/progress/step0" &&
+      path !== `/${themeSite}/step0` &&
+      (e.key === "Escape" || e.key === "esc")
+    ) {
       setIsPaused((prev) => !prev);
     }
     return;

--- a/src/pages/challengeMode/selectSite/SelectSite.jsx
+++ b/src/pages/challengeMode/selectSite/SelectSite.jsx
@@ -3,7 +3,7 @@ import styled from "styled-components";
 import { useNavigate } from "react-router-dom";
 import Button from "../../../components/button/Button";
 import { themeSiteAtom } from "../../../store/atom";
-import { useSetAtom } from "jotai";
+import { useAtomValue, useSetAtom } from "jotai";
 import interparkIcon from "../../../assests/images/icons/site/interpark.svg";
 import melonticketIcon from "../../../assests/images/icons/site/melonticket.svg";
 import tickelinkIcon from "../../../assests/images/icons/site/tickelink.svg";
@@ -40,7 +40,8 @@ const SelectSite = () => {
   const setThemeSite = useSetAtom(themeSiteAtom);
 
   useEffect(() => {
-    setThemeSite(null);
+    //theme 초기화
+    setThemeSite("practice");
   }, [setThemeSite]);
 
   const sites = [

--- a/src/pages/challengeMode/selectSite/SelectSite.jsx
+++ b/src/pages/challengeMode/selectSite/SelectSite.jsx
@@ -3,7 +3,7 @@ import styled from "styled-components";
 import { useNavigate } from "react-router-dom";
 import Button from "../../../components/button/Button";
 import { themeSiteAtom } from "../../../store/atom";
-import { useSetAtom, useAtom } from "jotai";
+import { useSetAtom } from "jotai";
 import interparkIcon from "../../../assests/images/icons/site/interpark.svg";
 import melonticketIcon from "../../../assests/images/icons/site/melonticket.svg";
 import tickelinkIcon from "../../../assests/images/icons/site/tickelink.svg";
@@ -62,7 +62,12 @@ const SelectSite = () => {
       path: "/ticketlink",
       theme: "ticketlink"
     },
-    { name: "예스24(YES24)", icon: yes24Icon, path: "/yes24", theme: "yes24" }
+    {
+      name: "예스24(YES24)",
+      icon: yes24Icon,
+      path: "/yes24/step0",
+      theme: "yes24"
+    }
   ];
 
   // 라우팅

--- a/src/pages/challengeMode/step0/ChallangeIntro.jsx
+++ b/src/pages/challengeMode/step0/ChallangeIntro.jsx
@@ -1,7 +1,7 @@
-import React, { useEffect } from "react";
+import React, { useEffect, useState } from "react";
 import styled from "styled-components";
 import { useNavigate } from "react-router-dom";
-import { useAtom, useSetAtom } from "jotai";
+import { useAtom, useAtomValue, useSetAtom } from "jotai";
 import { progressAtom, themeSiteAtom } from "../../../store/atom";
 import Button from "../../../components/button/Button";
 import AnimationArea from "../../../components/Animation";
@@ -18,7 +18,7 @@ const IntroContainer = styled.div`
 const ChallangeIntro = () => {
   const navigate = useNavigate();
   const [progress, setProgress] = useAtom(progressAtom);
-  const [themeSite] = useAtom(themeSiteAtom);
+  const themeSite = useAtomValue(themeSiteAtom);
 
   useEffect(() => {
     setProgress(0);
@@ -38,6 +38,9 @@ const ChallangeIntro = () => {
         break;
       case "yes24":
         navigate("/yes24/step1-1");
+        break;
+      default:
+        "practice";
         break;
     }
   };

--- a/src/pages/challengeMode/step0/introMessage/introText/IntroText.jsx
+++ b/src/pages/challengeMode/step0/introMessage/introText/IntroText.jsx
@@ -4,7 +4,6 @@ import "./IntroText.css";
 
 const Title = styled.div`
   font-size: 40px;
-  font-style: normal;
   letter-spacing: -2.5px;
   text-align: center;
   line-height: normal;
@@ -14,7 +13,6 @@ const Title = styled.div`
 const Main = styled.div`
   text-align: center;
   font-size: 25px;
-  font-style: normal;
   letter-spacing: -1.5px;
   line-height: normal;
   margin-bottom: 30px;

--- a/src/pages/challengeMode/yes24/SelectPerformYes24.jsx
+++ b/src/pages/challengeMode/yes24/SelectPerformYes24.jsx
@@ -1,0 +1,16 @@
+import { useEffect } from "react";
+
+const SelectPerformYes24 = () => {
+  const [, setThemeSite] = useAtom(themeSiteAtom);
+
+  useEffect(() => {
+    setProgress(1);
+    const [, setLevel] = useAtom(levelAtom);
+    const [, setProgress] = useAtom(progressAtom);
+    setThemeSite("interpark"); // Interpark 테마 적용
+    setLevel("high"); // 고급 난이도 설정
+    setPosterId(0);
+  }, [setLevel, setProgress, selectedPoster, setThemeSite]);
+  return <h1>yes24 페이지입니다</h1>;
+};
+export default SelectPerformYes24;

--- a/src/pages/main/Main.jsx
+++ b/src/pages/main/Main.jsx
@@ -3,7 +3,7 @@ import styled from "styled-components";
 import Button from "../../components/button/Button";
 import Animation from "../../components/Animation";
 import { useAtom, useSetAtom } from "jotai";
-import { userNameAtom, themeSiteAtom } from "../../store/atom";
+import { userNameAtom, themeSiteAtom, levelAtom } from "../../store/atom";
 import { useNavigate } from "react-router-dom";
 import MainImage from "../../assests/images/main.png";
 
@@ -57,10 +57,13 @@ const StyledMainImage = styled.img`
 function Main() {
   const [name, setName] = useAtom(userNameAtom);
   const setThemeSite = useSetAtom(themeSiteAtom);
+  const setLevel = useSetAtom(levelAtom);
   const navigate = useNavigate();
 
   useEffect(() => {
     setThemeSite(null);
+    setLevel(null);
+    setName(null);
   }, [setThemeSite]);
 
   const handleNameInput = (e) => {
@@ -70,11 +73,10 @@ function Main() {
 
   // 시작하기 클릭 시
   const handleClick = () => {
-    if (name === "") {
+    if (!name) {
       alert("이름을 입력해주세요.");
       return;
     }
-    sessionStorage.setItem("name", name);
     navigate("/select-mode");
   };
 

--- a/src/pages/selectMode/SelectMode.jsx
+++ b/src/pages/selectMode/SelectMode.jsx
@@ -1,11 +1,11 @@
 import React from "react";
 import styled from "styled-components";
 import { useAtomValue, useSetAtom } from "jotai";
-import { practiceCountAtom, themeSiteAtom } from "../../../store/atom";
+import { practiceCountAtom, themeSiteAtom } from "../../store/atom";
 import { useNavigate } from "react-router-dom";
-import Button from "../../../components/button/Button";
-import Tooltip from "../../../components/tooltip/Tooltip";
-import AnimationArea from "../../../components/Animation";
+import Button from "../../components/button/Button";
+import Tooltip from "../../components/tooltip/Tooltip";
+import AnimationArea from "../../components/Animation";
 
 const SelectLevelContainer = styled.div`
   display: flex;

--- a/src/routes.jsx
+++ b/src/routes.jsx
@@ -3,9 +3,9 @@ import { createBrowserRouter } from "react-router-dom";
 import Layout from "./pages/Layout";
 import ProgressContents from "./pages/ProgressContents";
 import Main from "./pages/main/Main";
-import SelectMode from "./pages/practiceMode/selectMode/SelectMode";
+import SelectMode from "./pages/selectMode/SelectMode";
 import SelectLevel from "./pages/practiceMode/selectLevel/SelectLevel";
-import SelectSite from "./pages/practiceMode/selectSite/SelectSite";
+import SelectSite from "./pages/challengeMode/selectSite/SelectSite";
 import Intro from "./pages/practiceMode/step0/Intro";
 import SelectPerformance from "./pages/practiceMode/step1/SelectPerformance";
 import SelectRound from "./pages/practiceMode/step1/SelectRound";
@@ -91,6 +91,17 @@ const router = createBrowserRouter([
             path: "step5",
             element: <PrivateRoute element={<Step5 />} />,
             label: "예매 성공"
+          }
+        ]
+      },
+      {
+        path: "yes24",
+        element: <ProgressContents />,
+        children: [
+          {
+            path: "step0",
+            element: <ChallangeIntro />,
+            lable: "인트로"
           }
         ]
       }

--- a/src/store/atom.js
+++ b/src/store/atom.js
@@ -67,10 +67,10 @@ export const allowedSectionAtom = atomWithStorage(
 );
 
 //사용자 이름
-export const userNameAtom = atomWithStorage("userName", "");
+export const userNameAtom = atomWithStorage("userName", "", storage);
 
 //연습모드 완료 횟수
-export const practiceCountAtom = atomWithStorage("practiceCount", 0);
+export const practiceCountAtom = atomWithStorage("practiceCount", 0, storage);
 
 //좌석 매수 개수
 export const seatCountAtom = atomWithStorage("seatCount", 0, storage);

--- a/src/styles/CustomThemeProvider.jsx
+++ b/src/styles/CustomThemeProvider.jsx
@@ -1,25 +1,13 @@
 import React, { createContext, useContext, useEffect } from "react";
-import { useAtom } from "jotai";
+import { useAtomValue } from "jotai";
 import { themeSiteAtom } from "../store/atom";
 
 const ThemeContext = createContext();
 
 export const CustomThemeProvider = ({ children }) => {
-  const [currentTheme, setCurrentTheme] = useAtom(themeSiteAtom);
+  const currentTheme = useAtomValue(themeSiteAtom);
 
   useEffect(() => {
-    const storedTheme = sessionStorage.getItem("themeSite");
-    if (storedTheme) {
-      setCurrentTheme(storedTheme); // 세션 스토리지에서 테마 읽기
-    } else {
-      setCurrentTheme(null); // 테마가 저장되어 있지 않은 경우 null로 설정
-    }
-  }, [setCurrentTheme]);
-
-  useEffect(() => {
-    const themeToApply = currentTheme || null; // 기본 테마 설정
-    sessionStorage.setItem("themeSite", themeToApply); // 세션 스토리지에 현재 테마 저장
-
     // module css 용
     // 모든 테마 클래스를 제거
     document.body.classList.remove(
@@ -31,7 +19,7 @@ export const CustomThemeProvider = ({ children }) => {
     );
 
     // 새로운 테마 클래스를 적용
-    const newThemeClass = `${themeToApply}-theme`; // 현재 테마 클래스 적용
+    const newThemeClass = `${currentTheme}-theme`; // 현재 테마 클래스 적용
     document.body.classList.add(newThemeClass); // 새로운 테마 클래스를 추가
 
     // console.log(`현재 테마: ${newThemeClass}`);


### PR DESCRIPTION
## 📝작업 내용
### ✅ themeSite 새로고침 시 풀리는 문제 해결
세션스토리지를 사용한다면 새로고침 시에도 바뀌지 않아야 한다

예상원인 (해결은 됐으나 아래 예상 원인들이 원인이 아니었을 수도 있음)
**1) 두 번의 세션스토리지 호출**

```javascript
useEffect(() => {
    const fetchTheme = () => {
      const storedTheme = sessionStorage.getItem("themeSite");
      if (storedTheme) {
        setThemeSite(storedTheme);
      } else {
        setThemeSite("practice");
      }
      setIsLoading(false);
    };
    fetchTheme();
  }, [setThemeSite]);
```   
```javascript
  useEffect(() => {
    const storedItem = useAtom()
    if (storedTheme) {
      setCurrentTheme(storedTheme); // 세션 스토리지에서 테마 읽기
    } else {
      setCurrentTheme(null); // 테마가 저장되어 있지 않은 경우 null로 설정
    }
  }, []);
``` 
**위 두 코드는 세션스토리지를 두 번 호출하는 문제를 발생시킴**
이미 themeSiteAtom은 const storage = createJSONStorage(() => sessionStorage); 이 코드를 이용하여 세션스토리지 값을 불러오거나 수정하고 있음. 즉, themeSiteAtom을 useAtomValue로 불러온다면 세션스토리지 값을 불러오는 것이고, setThemeSite를 통해 변경한다면 세션스토리지 값을 변경하는 것임

하지만 위 코드에선 sessionStorage에서 storedTheme이라는 변수로 값을 갖고와서 setThemeSite로 themeSiteAtom을 변경하고 있음. setThemeSite 자체가 sessionStorage.setItem 을 의미하는데 세션스토리지 값을 갖고와서 세션스토리지 값을 변화시킨다...의 코드가 돼버림 <br><br>


**2) themeSite값을 불러오는 과정의 비일관성**

**세션 스토리지 -> atom에서 초기화 -> atom에서 세션스토리지에 저장된 값 -> 각 컴포넌트 마다 불러오는 atom**
위 과정을 거쳐서 불러와야 하지만, CustomThemeProvider와 SelectSite 파일에서 **세션스토리지를 직접 호출**하거나 **세션스토리지를 두 번 호출** (1번과 동일) 하는 등의 비일관성 발생. 이게 위에 첨부한 useEffect 코드랑 섞임, atom이 초기화 되는 과정에서 새로고침 시에 중간에 null로 자꾸 납치됐던 것 같음

### ✅ 세션스토리지 문자열과 비문자열 원인 확인
마찬가지로 이미 themeSiteAtom은 const storage = createJSONStorage(() => sessionStorage); 이 코드를 이용하여 세션스토리지 값을 불러오거나 수정하고 있음. 위 코드는 문자열로 세션스토리지에 값을 입력하려고 하면 자동으로 JSON.stringfy 를 사용하고, 꺼낼 떄는 자동으로 JSON.parse를 사용함. 즉 **문자열로 입력되는 게 맞음**!! 세션스토리지 직접 호출하는 코드와 atom을 이용한 코드가 섞이면서 어떤 건 문자열로 갖고오고, 어떤 건 직접 세션스토리지에 접근하며 데이터 형식이 꼬인 것 같음. 2번을 수정하면서 자동적으로 해결 됨. 

> 이런 오류로 계속 고생해보니 Next.js를 사용하는 이유를 너무나도 잘 알겠음

### ✅ 그 외
1) 폴더 구조를 라우터 구조와 유사하게 변경
* select Mode는 practiceMode -> pages 폴더로 뺌
* select Site는 challengeMode 폴더로 변경함

2) 타이머 실전모드에서 제거
3) 실전모드 step0에서 esc 모달 렌더링 제한


## 💬리뷰 요구사항
* 세션스토리지가 아닌 로컬스토리지를 사용하고 있는 atom들이 있어서 세션스토리지로 바꿔줌  (사용자 이름, 연습모드 완료 횟수) : 일부러 로컬스토리지를 쓰고 있었던 게 있는지?
* 세션스토리지를 직접 호출하고 있는 모든 변수들 다 atom을 거쳐서 갖고오도록 변경함 : 최대한 확인할 만큼 확인은 했는데, 내가 코드를 바꾸면서 이상해진 부분이 있는지 지속적으로 확인을 해야 할 것 같음