### PR TITLE
Refactor: 실전 모드 작업을 위한 SeatInfo / 예매자 확인 폼 / 헤더 접근 제한 / 메인화면 리팩토링

### DIFF
--- a/src/components/ProgressBar.jsx
+++ b/src/components/ProgressBar.jsx
@@ -79,20 +79,6 @@ const Loading = styled.div`
 const ProgressBar = () => {
   const progress = useAtomValue(progressAtom);
   const [themeSite, setThemeSite] = useAtom(themeSiteAtom);
-  const [isLoading, setIsLoading] = useState(true);
-
-  useEffect(() => {
-    const fetchTheme = () => {
-      const storedTheme = sessionStorage.getItem("themeSite");
-      if (storedTheme) {
-        setThemeSite(storedTheme);
-      } else {
-        setThemeSite("practice");
-      }
-      setIsLoading(false);
-    };
-    fetchTheme();
-  }, [setThemeSite]);
 
   const steps = [
     "공연 및 회차선택",

--- a/src/components/forms/ticket/TicketBuyer.jsx
+++ b/src/components/forms/ticket/TicketBuyer.jsx
@@ -2,7 +2,7 @@ import styled from "styled-components";
 import { FormWrap } from "../FormStyle";
 import { InputContainer, Label } from "../../input/InputStyle";
 import { useAtomValue } from "jotai";
-import { levelAtom } from "../../../store/atom";
+import { levelAtom, userNameAtom } from "../../../store/atom";
 import { useState } from "react";
 
 const BuyerWrap = styled.div`
@@ -49,7 +49,7 @@ const InfoInput = styled(InfoBox).attrs({ as: "input" })`
 
 // mock buyer data
 const data_essential = [
-  { label: "이름", value: "홍길동" },
+  { label: "이름", value: "" },
   { label: "생년월일", value: "010110" },
   { label: "연락처", value: "010-1234-5678" },
   { label: "이메일", value: "abcd@gmai.com" }
@@ -62,6 +62,7 @@ const data_delivery = [
 ];
 
 const TicketBuyer = ({ option, setIsValidate, errorArray }) => {
+  const userName = useAtomValue(userNameAtom);
   //난이도 - 생년월일 입력 구현
   const level = useAtomValue(levelAtom);
   // 생년월일 입력 검사 로직
@@ -95,7 +96,10 @@ const TicketBuyer = ({ option, setIsValidate, errorArray }) => {
                   $hasError={hasError}
                 ></InfoInput>
               ) : (
-                <InfoBox>{item.value}</InfoBox>
+                <InfoBox>
+                  {/* 로그인 시 입력한 userName 값 가져오기 */}
+                  {item.label === "이름" ? userName : item.value}
+                </InfoBox>
               )}
             </InputContainer>
           ))}

--- a/src/components/header/nav/subNav/SubNav.jsx
+++ b/src/components/header/nav/subNav/SubNav.jsx
@@ -39,11 +39,6 @@ const SubNav = ({ hovereditem }) => {
   const setLevel = useSetAtom(levelAtom);
   const setThemeSite = useSetAtom(themeSiteAtom);
 
-  useEffect(() => {
-    // 기본 theme로 초기화
-    setThemeSite("practice");
-  }, [setThemeSite]);
-
   const handleSubNavClick = (e) => {
     const level =
       e.target.innerText === "초급"

--- a/src/components/header/nav/subNav/SubNav.jsx
+++ b/src/components/header/nav/subNav/SubNav.jsx
@@ -1,4 +1,3 @@
-import React, { useEffect } from "react";
 import styled from "styled-components";
 import { useNavigate } from "react-router-dom";
 import { levelAtom, themeSiteAtom } from "../../../../store/atom";
@@ -39,21 +38,14 @@ const SubNav = ({ hovereditem }) => {
   const setLevel = useSetAtom(levelAtom);
   const setThemeSite = useSetAtom(themeSiteAtom);
 
-  const handleSubNavClick = (e) => {
-    const level =
-      e.target.innerText === "초급"
-        ? "low"
-        : e.target.innerText === "중급"
-          ? "middle"
-          : "high";
-    setLevel(level);
-    nav("/progress/step0");
-  };
-
-  const handleSiteClick = (site) => {
-    setLevel("high");
-    setThemeSite(site);
-    nav(`/${site}/step0`); // 각 사이트의 인트로 페이지로 이동
+  const handleNavigate = (location) => {
+    if (location === "low" || location === "middle" || location === "high") {
+      setLevel(location); // 레벨 설정
+      nav("/progress/step0"); // 연습모드 step0로 이동
+    } else {
+      setThemeSite(location); // 테마 사이트 설정
+      nav(`/${location}/step0`); // 각 사이트의 인트로 페이지로 이동
+    }
   };
 
   return (
@@ -61,9 +53,15 @@ const SubNav = ({ hovereditem }) => {
       {hovereditem === "연습모드" && (
         <SubNavWrap>
           <SubNavContainer>
-            <SubNavContent onClick={handleSubNavClick}>초급</SubNavContent>
-            <SubNavContent onClick={handleSubNavClick}>중급</SubNavContent>
-            <SubNavContent onClick={handleSubNavClick}>고급</SubNavContent>
+            <SubNavContent onClick={() => handleNavigate("low")}>
+              초급
+            </SubNavContent>
+            <SubNavContent onClick={() => handleNavigate("mid")}>
+              중급
+            </SubNavContent>
+            <SubNavContent onClick={() => handleNavigate("high")}>
+              고급
+            </SubNavContent>
           </SubNavContainer>
         </SubNavWrap>
       )}
@@ -71,16 +69,16 @@ const SubNav = ({ hovereditem }) => {
       {hovereditem === "실전모드" && (
         <SubNavWrap>
           <SubNavContainer>
-            <SubNavContent onClick={() => handleSiteClick("interpark")}>
+            <SubNavContent onClick={() => handleNavigate("interpark")}>
               인터파크 티켓
             </SubNavContent>
-            <SubNavContent onClick={() => handleSiteClick("melonticket")}>
+            <SubNavContent onClick={() => handleNavigate("melonticket")}>
               멜론티켓
             </SubNavContent>
-            <SubNavContent onClick={() => handleSiteClick("yes24")}>
+            <SubNavContent onClick={() => handleNavigate("yes24")}>
               예스24
             </SubNavContent>
-            <SubNavContent onClick={() => handleSiteClick("ticketlink")}>
+            <SubNavContent onClick={() => handleNavigate("ticketlink")}>
               티켓링크
             </SubNavContent>
           </SubNavContainer>

--- a/src/components/header/nav/subNav/SubNav.jsx
+++ b/src/components/header/nav/subNav/SubNav.jsx
@@ -1,7 +1,7 @@
 import styled from "styled-components";
 import { useNavigate } from "react-router-dom";
-import { levelAtom, themeSiteAtom } from "../../../../store/atom";
-import { useSetAtom } from "jotai";
+import { levelAtom, themeSiteAtom, userNameAtom } from "../../../../store/atom";
+import { useAtomValue, useSetAtom } from "jotai";
 
 const SubNavWrap = styled.div`
   width: 1320px;
@@ -37,8 +37,15 @@ const SubNav = ({ hovereditem }) => {
   const nav = useNavigate();
   const setLevel = useSetAtom(levelAtom);
   const setThemeSite = useSetAtom(themeSiteAtom);
+  //접근 제한
+  const userName = useAtomValue(userNameAtom);
 
   const handleNavigate = (location) => {
+    //입력된 userName이 없을 경우 이동 제한
+    if (!userName) {
+      alert("성함을 입력해 주세요");
+      return;
+    }
     if (location === "low" || location === "middle" || location === "high") {
       setLevel(location); // 레벨 설정
       nav("/progress/step0"); // 연습모드 step0로 이동
@@ -56,7 +63,7 @@ const SubNav = ({ hovereditem }) => {
             <SubNavContent onClick={() => handleNavigate("low")}>
               초급
             </SubNavContent>
-            <SubNavContent onClick={() => handleNavigate("mid")}>
+            <SubNavContent onClick={() => handleNavigate("middle")}>
               중급
             </SubNavContent>
             <SubNavContent onClick={() => handleNavigate("high")}>

--- a/src/components/header/nav/subNav/SubNav.jsx
+++ b/src/components/header/nav/subNav/SubNav.jsx
@@ -1,3 +1,4 @@
+import React, { useEffect } from "react";
 import styled from "styled-components";
 import { useNavigate } from "react-router-dom";
 import { levelAtom, themeSiteAtom } from "../../../../store/atom";
@@ -38,6 +39,11 @@ const SubNav = ({ hovereditem }) => {
   const setLevel = useSetAtom(levelAtom);
   const setThemeSite = useSetAtom(themeSiteAtom);
 
+  useEffect(() => {
+    // 기본 theme로 초기화
+    setThemeSite("practice");
+  }, [setThemeSite]);
+
   const handleSubNavClick = (e) => {
     const level =
       e.target.innerText === "초급"
@@ -50,8 +56,9 @@ const SubNav = ({ hovereditem }) => {
   };
 
   const handleSiteClick = (site) => {
+    setLevel("high");
     setThemeSite(site);
-    nav(`/${site}`);
+    nav(`/${site}/step0`); // 각 사이트의 인트로 페이지로 이동
   };
 
   return (

--- a/src/components/seatInfo/SeatInfo.jsx
+++ b/src/components/seatInfo/SeatInfo.jsx
@@ -30,18 +30,24 @@ const SeatInfo = () => {
   const isSeatSelected = useAtomValue(isSeatSelectedAtom);
   const allowedSeat = useAtomValue(allowedSeatAtom);
   const level = useAtomValue(levelAtom);
-
   const posters = useAtomValue(postersAtom);
   const posterId = useAtomValue(selectedPosterAtom);
   const selectedPoster = posters[posterId];
-
   const seats = convertPriceObjectToArray(selectedPoster.price);
   const [seatInfo, setSeatInfo] = useAtom(seatInfoAtom);
+
   useEffect(() => {
     if (isSeatSelected) {
-      setSeatInfo(getRandomSeat(selectedPoster));
+      const newSeatInfo = getRandomSeat(selectedPoster);
+      setSeatInfo({
+        ...seatInfo,
+        grade: newSeatInfo.grade,
+        price: newSeatInfo.price,
+        date: newSeatInfo.date,
+        seat: `${allowedSeat.row + 1}열 ${allowedSeat.col + 1}`
+      });
     }
-  }, [isSeatSelected]);
+  }, [isSeatSelected, allowedSeat, selectedPoster]);
 
   let isFocus = false;
   if (isSeatSelected && level == "low") {
@@ -83,7 +89,7 @@ const SeatInfo = () => {
           {isSeatSelected && (
             <>
               <SeatInfoCont>{seatInfo.grade}</SeatInfoCont>
-              <SeatInfoCont>{`${allowedSeat.row + 1}열-${allowedSeat.col + 1}`}</SeatInfoCont>
+              <SeatInfoCont>{seatInfo.seat}</SeatInfoCont>
             </>
           )}
         </SelectedSeatsInfo>

--- a/src/pages/PrivateRoute.jsx
+++ b/src/pages/PrivateRoute.jsx
@@ -3,9 +3,14 @@ import { Navigate } from "react-router-dom";
 
 const PrivateRoute = ({ element }) => {
   //로컬 스토리지에 이름과 난이도가 설정되지 않았다면 메인 화면으로 이동
-  const isUser = sessionStorage.getItem("name");
+  const isUser = sessionStorage.getItem("userName");
   const isSelectedLevel = sessionStorage.getItem("level");
-  return isUser || isSelectedLevel ? element : <Navigate to="/" />;
+  const isSelectedSite = sessionStorage.getItem("themeSite");
+  return isUser && (isSelectedLevel || isSelectedSite) ? (
+    element
+  ) : (
+    <Navigate to="/" />
+  );
 };
 
 export default PrivateRoute;

--- a/src/pages/PrivateRoute.jsx
+++ b/src/pages/PrivateRoute.jsx
@@ -1,11 +1,14 @@
+import { useAtomValue } from "jotai";
 import React from "react";
 import { Navigate } from "react-router-dom";
+import { levelAtom, themeSiteAtom, userNameAtom } from "../store/atom";
 
 const PrivateRoute = ({ element }) => {
   //로컬 스토리지에 이름과 난이도가 설정되지 않았다면 메인 화면으로 이동
-  const isUser = sessionStorage.getItem("userName");
-  const isSelectedLevel = sessionStorage.getItem("level");
-  const isSelectedSite = sessionStorage.getItem("themeSite");
+  //주소 직접 접근 제한
+  const isUser = useAtomValue(userNameAtom);
+  const isSelectedLevel = useAtomValue(levelAtom);
+  const isSelectedSite = useAtomValue(themeSiteAtom);
   return isUser && (isSelectedLevel || isSelectedSite) ? (
     element
   ) : (

--- a/src/pages/ProgressContents.jsx
+++ b/src/pages/ProgressContents.jsx
@@ -53,6 +53,7 @@ const ProgressContents = ({ text }) => {
   const level = useAtomValue(levelAtom);
   //도움말 모달창 제어
   const [isModalOpen, setIsModalOpen] = useState(false);
+  //theme
   const themeSite = useAtomValue(themeSiteAtom);
 
   const handleModalOpen = () => {
@@ -91,7 +92,7 @@ const ProgressContents = ({ text }) => {
       </ProgressBarBox>
       {/*고급 level일 경우에만 Timer 설정 */}
       {/*모달이 열렸을 경우 Timer 정지*/}
-      {level === "high" && (
+      {level === "high" && themeSite === "practice" && (
         <Timer
           type={"minute"}
           second={1000}

--- a/src/pages/ProgressContents.jsx
+++ b/src/pages/ProgressContents.jsx
@@ -68,7 +68,12 @@ const ProgressContents = ({ text }) => {
   const path = useLocation().pathname;
   const [isPaused, setIsPaused] = useState(false);
   const handlePaused = (e) => {
-    if (path !== "/progress/step0" && (e.key === "Escape" || e.key === "esc")) {
+    if (
+      //연습모드 step0 또는 실전모드 step0에서 렌더링되지 않도록 설정
+      path !== "/progress/step0" &&
+      path !== `/${themeSite}/step0` &&
+      (e.key === "Escape" || e.key === "esc")
+    ) {
       setIsPaused((prev) => !prev);
     }
     return;

--- a/src/pages/challengeMode/selectSite/SelectSite.jsx
+++ b/src/pages/challengeMode/selectSite/SelectSite.jsx
@@ -3,7 +3,7 @@ import styled from "styled-components";
 import { useNavigate } from "react-router-dom";
 import Button from "../../../components/button/Button";
 import { themeSiteAtom } from "../../../store/atom";
-import { useSetAtom } from "jotai";
+import { useAtomValue, useSetAtom } from "jotai";
 import interparkIcon from "../../../assests/images/icons/site/interpark.svg";
 import melonticketIcon from "../../../assests/images/icons/site/melonticket.svg";
 import tickelinkIcon from "../../../assests/images/icons/site/tickelink.svg";
@@ -40,7 +40,8 @@ const SelectSite = () => {
   const setThemeSite = useSetAtom(themeSiteAtom);
 
   useEffect(() => {
-    setThemeSite(null);
+    //theme 초기화
+    setThemeSite("practice");
   }, [setThemeSite]);
 
   const sites = [

--- a/src/pages/challengeMode/selectSite/SelectSite.jsx
+++ b/src/pages/challengeMode/selectSite/SelectSite.jsx
@@ -2,7 +2,7 @@ import React, { useEffect } from "react";
 import styled from "styled-components";
 import { useNavigate } from "react-router-dom";
 import Button from "../../../components/button/Button";
-import { themeSiteAtom } from "../../../store/atom";
+import { themeSiteAtom, levelAtom } from "../../../store/atom";
 import { useAtomValue, useSetAtom } from "jotai";
 import interparkIcon from "../../../assests/images/icons/site/interpark.svg";
 import melonticketIcon from "../../../assests/images/icons/site/melonticket.svg";
@@ -38,11 +38,18 @@ const ButtonBox = styled.div`
 const SelectSite = () => {
   const navigate = useNavigate();
   const setThemeSite = useSetAtom(themeSiteAtom);
+  const setLevel = useSetAtom(levelAtom);
 
   useEffect(() => {
-    //theme 초기화
+    // 사이트 선택 페이지에서는 기본 theme로 초기화
     setThemeSite("practice");
   }, [setThemeSite]);
+
+  const handleClick = (path, themeSite) => {
+    setLevel("high"); // 사이트 클릭 시 고급 난이도 설정
+    setThemeSite(themeSite); // 해당 사이트의 테마로 변경
+    navigate(path);
+  };
 
   const sites = [
     {
@@ -70,12 +77,6 @@ const SelectSite = () => {
       theme: "yes24"
     }
   ];
-
-  // 라우팅
-  const handleClick = (path, theme) => {
-    setThemeSite(theme);
-    navigate(path);
-  };
 
   return (
     <SelectSiteContainer>

--- a/src/pages/challengeMode/selectSite/SelectSite.jsx
+++ b/src/pages/challengeMode/selectSite/SelectSite.jsx
@@ -55,19 +55,19 @@ const SelectSite = () => {
     {
       name: "인터파크 티켓",
       icon: interparkIcon,
-      path: "/interpark/step1", // 테마 적용 테스트 페이지
+      path: "/interpark/step0",
       theme: "interpark"
     },
     {
       name: "멜론티켓",
       icon: melonticketIcon,
-      path: "/melonticket",
+      path: "/melonticket/step0",
       theme: "melonticket"
     },
     {
       name: "티켓링크",
       icon: tickelinkIcon,
-      path: "/ticketlink",
+      path: "/ticketlink/step0",
       theme: "ticketlink"
     },
     {

--- a/src/pages/challengeMode/selectSite/SelectSite.jsx
+++ b/src/pages/challengeMode/selectSite/SelectSite.jsx
@@ -3,7 +3,7 @@ import styled from "styled-components";
 import { useNavigate } from "react-router-dom";
 import Button from "../../../components/button/Button";
 import { themeSiteAtom } from "../../../store/atom";
-import { useSetAtom, useAtom } from "jotai";
+import { useSetAtom } from "jotai";
 import interparkIcon from "../../../assests/images/icons/site/interpark.svg";
 import melonticketIcon from "../../../assests/images/icons/site/melonticket.svg";
 import tickelinkIcon from "../../../assests/images/icons/site/tickelink.svg";
@@ -62,7 +62,12 @@ const SelectSite = () => {
       path: "/ticketlink",
       theme: "ticketlink"
     },
-    { name: "예스24(YES24)", icon: yes24Icon, path: "/yes24", theme: "yes24" }
+    {
+      name: "예스24(YES24)",
+      icon: yes24Icon,
+      path: "/yes24/step0",
+      theme: "yes24"
+    }
   ];
 
   // 라우팅

--- a/src/pages/challengeMode/step0/ChallangeIntro.jsx
+++ b/src/pages/challengeMode/step0/ChallangeIntro.jsx
@@ -28,16 +28,16 @@ const ChallangeIntro = () => {
     setProgress(1);
     switch (themeSite) {
       case "interpark":
-        navigate("/interpark/step1-1");
+        navigate("/interpark/step1");
         break;
       case "melonticket":
-        navigate("/melonticket/step1-1");
+        navigate("/melonticket/step1");
         break;
       case "ticketlink":
-        navigate("/ticketlink/step1-1");
+        navigate("/ticketlink/step1");
         break;
       case "yes24":
-        navigate("/yes24/step1-1");
+        navigate("/yes24/step1");
         break;
       default:
         "practice";

--- a/src/pages/challengeMode/step0/ChallangeIntro.jsx
+++ b/src/pages/challengeMode/step0/ChallangeIntro.jsx
@@ -1,7 +1,7 @@
-import React, { useEffect } from "react";
+import React, { useEffect, useState } from "react";
 import styled from "styled-components";
 import { useNavigate } from "react-router-dom";
-import { useAtom, useSetAtom } from "jotai";
+import { useAtom, useAtomValue, useSetAtom } from "jotai";
 import { progressAtom, themeSiteAtom } from "../../../store/atom";
 import Button from "../../../components/button/Button";
 import AnimationArea from "../../../components/Animation";
@@ -18,7 +18,7 @@ const IntroContainer = styled.div`
 const ChallangeIntro = () => {
   const navigate = useNavigate();
   const [progress, setProgress] = useAtom(progressAtom);
-  const [themeSite] = useAtom(themeSiteAtom);
+  const themeSite = useAtomValue(themeSiteAtom);
 
   useEffect(() => {
     setProgress(0);
@@ -38,6 +38,9 @@ const ChallangeIntro = () => {
         break;
       case "yes24":
         navigate("/yes24/step1-1");
+        break;
+      default:
+        "practice";
         break;
     }
   };

--- a/src/pages/challengeMode/step0/introMessage/introText/IntroText.jsx
+++ b/src/pages/challengeMode/step0/introMessage/introText/IntroText.jsx
@@ -4,7 +4,6 @@ import "./IntroText.css";
 
 const Title = styled.div`
   font-size: 40px;
-  font-style: normal;
   letter-spacing: -2.5px;
   text-align: center;
   line-height: normal;
@@ -14,7 +13,6 @@ const Title = styled.div`
 const Main = styled.div`
   text-align: center;
   font-size: 25px;
-  font-style: normal;
   letter-spacing: -1.5px;
   line-height: normal;
   margin-bottom: 30px;

--- a/src/pages/challengeMode/yes24/SelectPerformYes24.jsx
+++ b/src/pages/challengeMode/yes24/SelectPerformYes24.jsx
@@ -1,0 +1,16 @@
+import { useEffect } from "react";
+
+const SelectPerformYes24 = () => {
+  const [, setThemeSite] = useAtom(themeSiteAtom);
+
+  useEffect(() => {
+    setProgress(1);
+    const [, setLevel] = useAtom(levelAtom);
+    const [, setProgress] = useAtom(progressAtom);
+    setThemeSite("interpark"); // Interpark 테마 적용
+    setLevel("high"); // 고급 난이도 설정
+    setPosterId(0);
+  }, [setLevel, setProgress, selectedPoster, setThemeSite]);
+  return <h1>yes24 페이지입니다</h1>;
+};
+export default SelectPerformYes24;

--- a/src/pages/main/Main.jsx
+++ b/src/pages/main/Main.jsx
@@ -3,7 +3,7 @@ import styled from "styled-components";
 import Button from "../../components/button/Button";
 import Animation from "../../components/Animation";
 import { useAtom, useSetAtom } from "jotai";
-import { userNameAtom, themeSiteAtom } from "../../store/atom";
+import { userNameAtom, themeSiteAtom, levelAtom } from "../../store/atom";
 import { useNavigate } from "react-router-dom";
 import MainImage from "../../assests/images/main.png";
 
@@ -57,10 +57,13 @@ const StyledMainImage = styled.img`
 function Main() {
   const [name, setName] = useAtom(userNameAtom);
   const setThemeSite = useSetAtom(themeSiteAtom);
+  const setLevel = useSetAtom(levelAtom);
   const navigate = useNavigate();
 
   useEffect(() => {
     setThemeSite(null);
+    setLevel(null);
+    setName(null);
   }, [setThemeSite]);
 
   const handleNameInput = (e) => {
@@ -70,11 +73,10 @@ function Main() {
 
   // 시작하기 클릭 시
   const handleClick = () => {
-    if (name === "") {
+    if (!name) {
       alert("이름을 입력해주세요.");
       return;
     }
-    sessionStorage.setItem("name", name);
     navigate("/select-mode");
   };
 

--- a/src/pages/selectMode/SelectMode.jsx
+++ b/src/pages/selectMode/SelectMode.jsx
@@ -1,11 +1,11 @@
 import React from "react";
 import styled from "styled-components";
 import { useAtomValue, useSetAtom } from "jotai";
-import { practiceCountAtom, themeSiteAtom } from "../../../store/atom";
+import { practiceCountAtom, themeSiteAtom } from "../../store/atom";
 import { useNavigate } from "react-router-dom";
-import Button from "../../../components/button/Button";
-import Tooltip from "../../../components/tooltip/Tooltip";
-import AnimationArea from "../../../components/Animation";
+import Button from "../../components/button/Button";
+import Tooltip from "../../components/tooltip/Tooltip";
+import AnimationArea from "../../components/Animation";
 
 const SelectLevelContainer = styled.div`
   display: flex;

--- a/src/routes.jsx
+++ b/src/routes.jsx
@@ -95,6 +95,28 @@ const router = createBrowserRouter([
         ]
       },
       {
+        path: "melonticket",
+        element: <ProgressContents />,
+        children: [
+          {
+            path: "step0",
+            element: <ChallangeIntro />,
+            lable: "인트로"
+          }
+        ]
+      },
+      {
+        path: "ticketlink",
+        element: <ProgressContents />,
+        children: [
+          {
+            path: "step0",
+            element: <ChallangeIntro />,
+            lable: "인트로"
+          }
+        ]
+      },
+      {
         path: "yes24",
         element: <ProgressContents />,
         children: [

--- a/src/routes.jsx
+++ b/src/routes.jsx
@@ -33,7 +33,7 @@ const router = createBrowserRouter([
         children: [
           {
             path: "step0",
-            element: <Intro />,
+            element: <PrivateRoute element={<Intro />} />,
             label: "인트로 화면"
           },
           {
@@ -100,7 +100,7 @@ const router = createBrowserRouter([
         children: [
           {
             path: "step0",
-            element: <ChallangeIntro />,
+            element: <PrivateRoute element={<ChallangeIntro />} />,
             lable: "인트로"
           }
         ]
@@ -111,7 +111,7 @@ const router = createBrowserRouter([
         children: [
           {
             path: "step0",
-            element: <ChallangeIntro />,
+            element: <PrivateRoute element={<ChallangeIntro />} />,
             lable: "인트로"
           }
         ]
@@ -122,7 +122,7 @@ const router = createBrowserRouter([
         children: [
           {
             path: "step0",
-            element: <ChallangeIntro />,
+            element: <PrivateRoute element={<ChallangeIntro />} />,
             lable: "인트로"
           }
         ]

--- a/src/routes.jsx
+++ b/src/routes.jsx
@@ -3,9 +3,9 @@ import { createBrowserRouter } from "react-router-dom";
 import Layout from "./pages/Layout";
 import ProgressContents from "./pages/ProgressContents";
 import Main from "./pages/main/Main";
-import SelectMode from "./pages/practiceMode/selectMode/SelectMode";
+import SelectMode from "./pages/selectMode/SelectMode";
 import SelectLevel from "./pages/practiceMode/selectLevel/SelectLevel";
-import SelectSite from "./pages/practiceMode/selectSite/SelectSite";
+import SelectSite from "./pages/challengeMode/selectSite/SelectSite";
 import Intro from "./pages/practiceMode/step0/Intro";
 import SelectPerformance from "./pages/practiceMode/step1/SelectPerformance";
 import SelectRound from "./pages/practiceMode/step1/SelectRound";
@@ -91,6 +91,17 @@ const router = createBrowserRouter([
             path: "step5",
             element: <PrivateRoute element={<Step5 />} />,
             label: "예매 성공"
+          }
+        ]
+      },
+      {
+        path: "yes24",
+        element: <ProgressContents />,
+        children: [
+          {
+            path: "step0",
+            element: <ChallangeIntro />,
+            lable: "인트로"
           }
         ]
       }

--- a/src/store/atom.js
+++ b/src/store/atom.js
@@ -67,10 +67,10 @@ export const allowedSectionAtom = atomWithStorage(
 );
 
 //사용자 이름
-export const userNameAtom = atomWithStorage("userName", "");
+export const userNameAtom = atomWithStorage("userName", "", storage);
 
 //연습모드 완료 횟수
-export const practiceCountAtom = atomWithStorage("practiceCount", 0);
+export const practiceCountAtom = atomWithStorage("practiceCount", 0, storage);
 
 //좌석 매수 개수
 export const seatCountAtom = atomWithStorage("seatCount", 0, storage);

--- a/src/store/atom.js
+++ b/src/store/atom.js
@@ -75,13 +75,14 @@ export const practiceCountAtom = atomWithStorage("practiceCount", 0, storage);
 //좌석 매수 개수
 export const seatCountAtom = atomWithStorage("seatCount", 0, storage);
 
-//좌석 등급, 가격
+// 좌석 등급, 가격, 좌석 정보 상태
 export const seatInfoAtom = atomWithStorage(
   "seatInfo",
   {
     grade: "",
     price: 0,
-    date: ""
+    date: "",
+    seat: ""
   },
   storage
 );

--- a/src/styles/CustomThemeProvider.jsx
+++ b/src/styles/CustomThemeProvider.jsx
@@ -1,25 +1,13 @@
 import React, { createContext, useContext, useEffect } from "react";
-import { useAtom } from "jotai";
+import { useAtomValue } from "jotai";
 import { themeSiteAtom } from "../store/atom";
 
 const ThemeContext = createContext();
 
 export const CustomThemeProvider = ({ children }) => {
-  const [currentTheme, setCurrentTheme] = useAtom(themeSiteAtom);
+  const currentTheme = useAtomValue(themeSiteAtom);
 
   useEffect(() => {
-    const storedTheme = sessionStorage.getItem("themeSite");
-    if (storedTheme) {
-      setCurrentTheme(storedTheme); // 세션 스토리지에서 테마 읽기
-    } else {
-      setCurrentTheme(null); // 테마가 저장되어 있지 않은 경우 null로 설정
-    }
-  }, [setCurrentTheme]);
-
-  useEffect(() => {
-    const themeToApply = currentTheme || null; // 기본 테마 설정
-    sessionStorage.setItem("themeSite", themeToApply); // 세션 스토리지에 현재 테마 저장
-
     // module css 용
     // 모든 테마 클래스를 제거
     document.body.classList.remove(
@@ -31,7 +19,7 @@ export const CustomThemeProvider = ({ children }) => {
     );
 
     // 새로운 테마 클래스를 적용
-    const newThemeClass = `${themeToApply}-theme`; // 현재 테마 클래스 적용
+    const newThemeClass = `${currentTheme}-theme`; // 현재 테마 클래스 적용
     document.body.classList.add(newThemeClass); // 새로운 테마 클래스를 추가
 
     // console.log(`현재 테마: ${newThemeClass}`);

--- a/src/util/getRandomSeat.js
+++ b/src/util/getRandomSeat.js
@@ -1,14 +1,17 @@
 import convertPriceToNumber from "./convertPriceToNumber";
+
 function getRandomSeat(poster) {
   const seatNames = Object.keys(poster.price);
-
   const randomIndex = Math.floor(Math.random() * seatNames.length);
-
   const randomSeat = seatNames[randomIndex];
-
   const randomPrice = convertPriceToNumber(poster.price[randomSeat]);
 
-  return { grade: randomSeat, price: randomPrice, date: poster.date };
+  return {
+    grade: randomSeat,
+    price: randomPrice,
+    date: poster.date[0],
+    seat: poster.seat
+  };
 }
 
 export default getRandomSeat;


### PR DESCRIPTION
# 📝작업 내용
- **SeatInfo에 seat 정보 추가**
  - 선택 좌석 열정보과 행 정보를 저장, 실전모드 제작 시 필요할 것 같아 atom에도 추가 함.
  - 활용할 곳 예시 - 좌석 (yes24)
![image](https://github.com/user-attachments/assets/f3e20d1f-9bfc-4e07-8fb8-65e31b733343)

- **step3 예매자 확인란에서 이름을 홍길동 대신 로그인 시 입력한 userName 받아와서 넣어줌**

- **실전 모드 작업을 위한 추가 설정**
  - 사이트 선택 페이지에서 클릭 시 난이도 high로 설정
  - 각 사이트 클릭 시 step0에 실전모드 인트로 페이지 라우팅
  - 헤더 네비바에서 실전모드 인트로 페이지 라우팅

* **헤더 접근 제한**
- PrivateRoute 파일은 주소로 직접 접근할 시 '리다이렉트' 해주는 파일
- 접근 제한에 대한 처리 (ex) 모달로 알림 띄우기, 폼에 focus하기) 는 해당 컴포넌트에서 필요, 전역 상태로 관리

## 스크린샷 (선택)
![2024-08-21 15 13 00](https://github.com/user-attachments/assets/ed678773-83f1-403a-b96c-bb887578f636)
![2024-08-21 15 03 25](https://github.com/user-attachments/assets/9dd3520d-d095-460a-97c9-fe36ba68ba02)

## 💬리뷰 요구사항
헤더까지 라우팅을 완료했는데, 현재 이름을 입력하지 않고 헤더에서 연습이나 실전모드로 바로 이동이 가능한 것 같아. 혹시 userName이 null이라면 시작하지 못하도록 하는 게 좋을까?
