### PR TITLE
Refactor : 유저네임 없을 시 focus 처리

### DIFF
--- a/src/components/forms/ticket/TicketBuyer.jsx
+++ b/src/components/forms/ticket/TicketBuyer.jsx
@@ -2,7 +2,7 @@ import styled from "styled-components";
 import { FormWrap } from "../FormStyle";
 import { InputContainer, Label } from "../../input/InputStyle";
 import { useAtomValue } from "jotai";
-import { levelAtom } from "../../../store/atom";
+import { levelAtom, userNameAtom } from "../../../store/atom";
 import { useState } from "react";
 
 const BuyerWrap = styled.div`
@@ -49,7 +49,7 @@ const InfoInput = styled(InfoBox).attrs({ as: "input" })`
 
 // mock buyer data
 const data_essential = [
-  { label: "이름", value: "홍길동" },
+  { label: "이름", value: "" },
   { label: "생년월일", value: "010110" },
   { label: "연락처", value: "010-1234-5678" },
   { label: "이메일", value: "abcd@gmai.com" }
@@ -62,6 +62,7 @@ const data_delivery = [
 ];
 
 const TicketBuyer = ({ option, setIsValidate, errorArray }) => {
+  const userName = useAtomValue(userNameAtom);
   //난이도 - 생년월일 입력 구현
   const level = useAtomValue(levelAtom);
   // 생년월일 입력 검사 로직
@@ -95,7 +96,10 @@ const TicketBuyer = ({ option, setIsValidate, errorArray }) => {
                   $hasError={hasError}
                 ></InfoInput>
               ) : (
-                <InfoBox>{item.value}</InfoBox>
+                <InfoBox>
+                  {/* 로그인 시 입력한 userName 값 가져오기 */}
+                  {item.label === "이름" ? userName : item.value}
+                </InfoBox>
               )}
             </InputContainer>
           ))}

--- a/src/components/header/nav/subNav/SubNav.jsx
+++ b/src/components/header/nav/subNav/SubNav.jsx
@@ -39,11 +39,6 @@ const SubNav = ({ hovereditem }) => {
   const setLevel = useSetAtom(levelAtom);
   const setThemeSite = useSetAtom(themeSiteAtom);
 
-  useEffect(() => {
-    // 기본 theme로 초기화
-    setThemeSite("practice");
-  }, [setThemeSite]);
-
   const handleSubNavClick = (e) => {
     const level =
       e.target.innerText === "초급"

--- a/src/components/header/nav/subNav/SubNav.jsx
+++ b/src/components/header/nav/subNav/SubNav.jsx
@@ -1,4 +1,3 @@
-import React, { useEffect } from "react";
 import styled from "styled-components";
 import { useNavigate } from "react-router-dom";
 import { levelAtom, themeSiteAtom } from "../../../../store/atom";
@@ -39,21 +38,14 @@ const SubNav = ({ hovereditem }) => {
   const setLevel = useSetAtom(levelAtom);
   const setThemeSite = useSetAtom(themeSiteAtom);
 
-  const handleSubNavClick = (e) => {
-    const level =
-      e.target.innerText === "초급"
-        ? "low"
-        : e.target.innerText === "중급"
-          ? "middle"
-          : "high";
-    setLevel(level);
-    nav("/progress/step0");
-  };
-
-  const handleSiteClick = (site) => {
-    setLevel("high");
-    setThemeSite(site);
-    nav(`/${site}/step0`); // 각 사이트의 인트로 페이지로 이동
+  const handleNavigate = (location) => {
+    if (location === "low" || location === "middle" || location === "high") {
+      setLevel(location); // 레벨 설정
+      nav("/progress/step0"); // 연습모드 step0로 이동
+    } else {
+      setThemeSite(location); // 테마 사이트 설정
+      nav(`/${location}/step0`); // 각 사이트의 인트로 페이지로 이동
+    }
   };
 
   return (
@@ -61,9 +53,15 @@ const SubNav = ({ hovereditem }) => {
       {hovereditem === "연습모드" && (
         <SubNavWrap>
           <SubNavContainer>
-            <SubNavContent onClick={handleSubNavClick}>초급</SubNavContent>
-            <SubNavContent onClick={handleSubNavClick}>중급</SubNavContent>
-            <SubNavContent onClick={handleSubNavClick}>고급</SubNavContent>
+            <SubNavContent onClick={() => handleNavigate("low")}>
+              초급
+            </SubNavContent>
+            <SubNavContent onClick={() => handleNavigate("mid")}>
+              중급
+            </SubNavContent>
+            <SubNavContent onClick={() => handleNavigate("high")}>
+              고급
+            </SubNavContent>
           </SubNavContainer>
         </SubNavWrap>
       )}
@@ -71,16 +69,16 @@ const SubNav = ({ hovereditem }) => {
       {hovereditem === "실전모드" && (
         <SubNavWrap>
           <SubNavContainer>
-            <SubNavContent onClick={() => handleSiteClick("interpark")}>
+            <SubNavContent onClick={() => handleNavigate("interpark")}>
               인터파크 티켓
             </SubNavContent>
-            <SubNavContent onClick={() => handleSiteClick("melonticket")}>
+            <SubNavContent onClick={() => handleNavigate("melonticket")}>
               멜론티켓
             </SubNavContent>
-            <SubNavContent onClick={() => handleSiteClick("yes24")}>
+            <SubNavContent onClick={() => handleNavigate("yes24")}>
               예스24
             </SubNavContent>
-            <SubNavContent onClick={() => handleSiteClick("ticketlink")}>
+            <SubNavContent onClick={() => handleNavigate("ticketlink")}>
               티켓링크
             </SubNavContent>
           </SubNavContainer>

--- a/src/components/header/nav/subNav/SubNav.jsx
+++ b/src/components/header/nav/subNav/SubNav.jsx
@@ -1,6 +1,11 @@
 import styled from "styled-components";
 import { useNavigate } from "react-router-dom";
-import { levelAtom, themeSiteAtom, userNameAtom } from "../../../../store/atom";
+import {
+  levelAtom,
+  themeSiteAtom,
+  userNameAtom,
+  userNameErrorAtom
+} from "../../../../store/atom";
 import { useAtomValue, useSetAtom } from "jotai";
 
 const SubNavWrap = styled.div`
@@ -37,13 +42,14 @@ const SubNav = ({ hovereditem }) => {
   const nav = useNavigate();
   const setLevel = useSetAtom(levelAtom);
   const setThemeSite = useSetAtom(themeSiteAtom);
-  //접근 제한
+  //접근 시 에러 발생
   const userName = useAtomValue(userNameAtom);
+  const setUserNameError = useSetAtom(userNameErrorAtom);
 
   const handleNavigate = (location) => {
-    //입력된 userName이 없을 경우 이동 제한
+    //입력된 userName이 없을 경우
     if (!userName) {
-      alert("성함을 입력해 주세요");
+      setUserNameError(true);
       return;
     }
     if (location === "low" || location === "middle" || location === "high") {

--- a/src/components/header/nav/subNav/SubNav.jsx
+++ b/src/components/header/nav/subNav/SubNav.jsx
@@ -1,7 +1,7 @@
 import styled from "styled-components";
 import { useNavigate } from "react-router-dom";
-import { levelAtom, themeSiteAtom } from "../../../../store/atom";
-import { useSetAtom } from "jotai";
+import { levelAtom, themeSiteAtom, userNameAtom } from "../../../../store/atom";
+import { useAtomValue, useSetAtom } from "jotai";
 
 const SubNavWrap = styled.div`
   width: 1320px;
@@ -37,8 +37,15 @@ const SubNav = ({ hovereditem }) => {
   const nav = useNavigate();
   const setLevel = useSetAtom(levelAtom);
   const setThemeSite = useSetAtom(themeSiteAtom);
+  //접근 제한
+  const userName = useAtomValue(userNameAtom);
 
   const handleNavigate = (location) => {
+    //입력된 userName이 없을 경우 이동 제한
+    if (!userName) {
+      alert("성함을 입력해 주세요");
+      return;
+    }
     if (location === "low" || location === "middle" || location === "high") {
       setLevel(location); // 레벨 설정
       nav("/progress/step0"); // 연습모드 step0로 이동
@@ -56,7 +63,7 @@ const SubNav = ({ hovereditem }) => {
             <SubNavContent onClick={() => handleNavigate("low")}>
               초급
             </SubNavContent>
-            <SubNavContent onClick={() => handleNavigate("mid")}>
+            <SubNavContent onClick={() => handleNavigate("middle")}>
               중급
             </SubNavContent>
             <SubNavContent onClick={() => handleNavigate("high")}>

--- a/src/components/header/nav/subNav/SubNav.jsx
+++ b/src/components/header/nav/subNav/SubNav.jsx
@@ -1,3 +1,4 @@
+import React, { useEffect } from "react";
 import styled from "styled-components";
 import { useNavigate } from "react-router-dom";
 import { levelAtom, themeSiteAtom } from "../../../../store/atom";
@@ -38,6 +39,11 @@ const SubNav = ({ hovereditem }) => {
   const setLevel = useSetAtom(levelAtom);
   const setThemeSite = useSetAtom(themeSiteAtom);
 
+  useEffect(() => {
+    // 기본 theme로 초기화
+    setThemeSite("practice");
+  }, [setThemeSite]);
+
   const handleSubNavClick = (e) => {
     const level =
       e.target.innerText === "초급"
@@ -50,8 +56,9 @@ const SubNav = ({ hovereditem }) => {
   };
 
   const handleSiteClick = (site) => {
+    setLevel("high");
     setThemeSite(site);
-    nav(`/${site}`);
+    nav(`/${site}/step0`); // 각 사이트의 인트로 페이지로 이동
   };
 
   return (

--- a/src/components/seatInfo/SeatInfo.jsx
+++ b/src/components/seatInfo/SeatInfo.jsx
@@ -30,18 +30,24 @@ const SeatInfo = () => {
   const isSeatSelected = useAtomValue(isSeatSelectedAtom);
   const allowedSeat = useAtomValue(allowedSeatAtom);
   const level = useAtomValue(levelAtom);
-
   const posters = useAtomValue(postersAtom);
   const posterId = useAtomValue(selectedPosterAtom);
   const selectedPoster = posters[posterId];
-
   const seats = convertPriceObjectToArray(selectedPoster.price);
   const [seatInfo, setSeatInfo] = useAtom(seatInfoAtom);
+
   useEffect(() => {
     if (isSeatSelected) {
-      setSeatInfo(getRandomSeat(selectedPoster));
+      const newSeatInfo = getRandomSeat(selectedPoster);
+      setSeatInfo({
+        ...seatInfo,
+        grade: newSeatInfo.grade,
+        price: newSeatInfo.price,
+        date: newSeatInfo.date,
+        seat: `${allowedSeat.row + 1}열 ${allowedSeat.col + 1}`
+      });
     }
-  }, [isSeatSelected]);
+  }, [isSeatSelected, allowedSeat, selectedPoster]);
 
   let isFocus = false;
   if (isSeatSelected && level == "low") {
@@ -83,7 +89,7 @@ const SeatInfo = () => {
           {isSeatSelected && (
             <>
               <SeatInfoCont>{seatInfo.grade}</SeatInfoCont>
-              <SeatInfoCont>{`${allowedSeat.row + 1}열-${allowedSeat.col + 1}`}</SeatInfoCont>
+              <SeatInfoCont>{seatInfo.seat}</SeatInfoCont>
             </>
           )}
         </SelectedSeatsInfo>

--- a/src/components/tooltip/ErrorTooltip.jsx
+++ b/src/components/tooltip/ErrorTooltip.jsx
@@ -1,0 +1,42 @@
+import styled, { keyframes } from "styled-components";
+const moveUpDown = keyframes`
+    0%{
+        transform: translateY(0);
+    }
+    50%{
+        transform: translateY(5px)
+    }
+    100%{
+        transform: translateY(0);
+    }
+`;
+const ErrorTooltipContainer = styled.div`
+  display: inline-flex;
+  padding: 15px 50px;
+  justify-content: center;
+  align-items: center;
+  background-color: var(--point-color2);
+  border-radius: 8px;
+  position: relative;
+
+  /* 꼬리 스타일 */
+  &::after {
+    content: "";
+    position: absolute;
+    bottom: -9px; /* 툴팁의 하단에 꼬리가 위치하도록 설정 */
+    left: 50%;
+    transform: translateX(-50%); /* 꼬리를 가운데 정렬 */
+    width: 0;
+    height: 0;
+    border-left: 10px solid transparent; /* 삼각형 꼬리 */
+    border-right: 10px solid transparent;
+    border-top: 10px solid var(--point-color2); /* 꼬리의 색상 */
+  }
+  animation: ${moveUpDown} 1s infinite;
+`;
+
+const ErrorTooltip = ({ contents }) => {
+  return <ErrorTooltipContainer>{contents}</ErrorTooltipContainer>;
+};
+
+export default ErrorTooltip;

--- a/src/pages/PrivateRoute.jsx
+++ b/src/pages/PrivateRoute.jsx
@@ -1,11 +1,14 @@
+import { useAtomValue } from "jotai";
 import React from "react";
 import { Navigate } from "react-router-dom";
+import { levelAtom, themeSiteAtom, userNameAtom } from "../store/atom";
 
 const PrivateRoute = ({ element }) => {
   //로컬 스토리지에 이름과 난이도가 설정되지 않았다면 메인 화면으로 이동
-  const isUser = sessionStorage.getItem("userName");
-  const isSelectedLevel = sessionStorage.getItem("level");
-  const isSelectedSite = sessionStorage.getItem("themeSite");
+  //주소 직접 접근 제한
+  const isUser = useAtomValue(userNameAtom);
+  const isSelectedLevel = useAtomValue(levelAtom);
+  const isSelectedSite = useAtomValue(themeSiteAtom);
   return isUser && (isSelectedLevel || isSelectedSite) ? (
     element
   ) : (

--- a/src/pages/challengeMode/selectSite/SelectSite.jsx
+++ b/src/pages/challengeMode/selectSite/SelectSite.jsx
@@ -2,7 +2,7 @@ import React, { useEffect } from "react";
 import styled from "styled-components";
 import { useNavigate } from "react-router-dom";
 import Button from "../../../components/button/Button";
-import { themeSiteAtom } from "../../../store/atom";
+import { themeSiteAtom, levelAtom } from "../../../store/atom";
 import { useAtomValue, useSetAtom } from "jotai";
 import interparkIcon from "../../../assests/images/icons/site/interpark.svg";
 import melonticketIcon from "../../../assests/images/icons/site/melonticket.svg";
@@ -38,11 +38,18 @@ const ButtonBox = styled.div`
 const SelectSite = () => {
   const navigate = useNavigate();
   const setThemeSite = useSetAtom(themeSiteAtom);
+  const setLevel = useSetAtom(levelAtom);
 
   useEffect(() => {
-    //theme 초기화
+    // 사이트 선택 페이지에서는 기본 theme로 초기화
     setThemeSite("practice");
   }, [setThemeSite]);
+
+  const handleClick = (path, themeSite) => {
+    setLevel("high"); // 사이트 클릭 시 고급 난이도 설정
+    setThemeSite(themeSite); // 해당 사이트의 테마로 변경
+    navigate(path);
+  };
 
   const sites = [
     {
@@ -70,12 +77,6 @@ const SelectSite = () => {
       theme: "yes24"
     }
   ];
-
-  // 라우팅
-  const handleClick = (path, theme) => {
-    setThemeSite(theme);
-    navigate(path);
-  };
 
   return (
     <SelectSiteContainer>

--- a/src/pages/challengeMode/selectSite/SelectSite.jsx
+++ b/src/pages/challengeMode/selectSite/SelectSite.jsx
@@ -55,19 +55,19 @@ const SelectSite = () => {
     {
       name: "인터파크 티켓",
       icon: interparkIcon,
-      path: "/interpark/step1", // 테마 적용 테스트 페이지
+      path: "/interpark/step0",
       theme: "interpark"
     },
     {
       name: "멜론티켓",
       icon: melonticketIcon,
-      path: "/melonticket",
+      path: "/melonticket/step0",
       theme: "melonticket"
     },
     {
       name: "티켓링크",
       icon: tickelinkIcon,
-      path: "/ticketlink",
+      path: "/ticketlink/step0",
       theme: "ticketlink"
     },
     {

--- a/src/pages/challengeMode/step0/ChallangeIntro.jsx
+++ b/src/pages/challengeMode/step0/ChallangeIntro.jsx
@@ -28,16 +28,16 @@ const ChallangeIntro = () => {
     setProgress(1);
     switch (themeSite) {
       case "interpark":
-        navigate("/interpark/step1-1");
+        navigate("/interpark/step1");
         break;
       case "melonticket":
-        navigate("/melonticket/step1-1");
+        navigate("/melonticket/step1");
         break;
       case "ticketlink":
-        navigate("/ticketlink/step1-1");
+        navigate("/ticketlink/step1");
         break;
       case "yes24":
-        navigate("/yes24/step1-1");
+        navigate("/yes24/step1");
         break;
       default:
         "practice";

--- a/src/pages/main/Main.jsx
+++ b/src/pages/main/Main.jsx
@@ -3,9 +3,16 @@ import styled from "styled-components";
 import Button from "../../components/button/Button";
 import Animation from "../../components/Animation";
 import { useAtom, useSetAtom } from "jotai";
-import { userNameAtom, themeSiteAtom, levelAtom } from "../../store/atom";
+import {
+  userNameAtom,
+  themeSiteAtom,
+  levelAtom,
+  userNameErrorAtom
+} from "../../store/atom";
 import { useNavigate } from "react-router-dom";
 import MainImage from "../../assests/images/main.png";
+import { InputField } from "../../components/input/InputStyle";
+import ErrorTooltip from "../../components/tooltip/ErrorTooltip";
 
 const MainContainer = styled.div`
   display: flex;
@@ -23,12 +30,13 @@ const Instructions = styled.p`
   font-style: normal;
   font-weight: 500;
   line-height: normal;
+  margin-bottom: 30px;
 `;
 
 const InputGroup = styled.div`
   display: flex;
   align-items: center;
-  margin: 20px 0;
+  margin: 30px 0;
   font-size: 20px;
 `;
 
@@ -37,10 +45,12 @@ const Label = styled.label`
   font-family: pretendardB;
 `;
 
-const Input = styled.input`
+const Input = styled(InputField)`
   height: 40px;
-  width: 200px;
-  border: 1px solid var(--fill-color);
+  border: ${(props) =>
+    props.$hasError
+      ? "2px solid var(--point-color)"
+      : "2px solid var(--fill-color)"};
   border-radius: 4px;
   font-family: pretendardB;
   font-size: 18px;
@@ -59,6 +69,8 @@ function Main() {
   const setThemeSite = useSetAtom(themeSiteAtom);
   const setLevel = useSetAtom(levelAtom);
   const navigate = useNavigate();
+  //userName 작성하지 않고 시작하기를 누르거나 헤더 이동시
+  const [userNameError, setUserNameError] = useAtom(userNameErrorAtom);
 
   useEffect(() => {
     setThemeSite(null);
@@ -68,13 +80,16 @@ function Main() {
 
   const handleNameInput = (e) => {
     const name = e.target.value;
+    //userName 입력 시 빨간색 바운더리 꺼짐
+    setUserNameError(false);
     setName(name);
   };
 
   // 시작하기 클릭 시
   const handleClick = () => {
     if (!name) {
-      alert("이름을 입력해주세요.");
+      alert("성함을 입력해주세요.");
+      setUserNameError(true);
       return;
     }
     navigate("/select-mode");
@@ -83,19 +98,23 @@ function Main() {
   return (
     <MainContainer>
       <StyledMainImage src={MainImage} alt="main image" />
+      {/*안내 문구 */}
       <Instructions>
         아래 빈칸에 성함을 입력하신 후,{" "}
         <span style={{ color: "var(--key-color)" }}>‘시작하기’</span> 버튼을
         클릭해 주세요.
       </Instructions>
 
+      {/*userName 없는 오류 안내 문구*/}
+      {userNameError && <ErrorTooltip contents="성함을 입력해 주세요" />}
+      {/*userName 입력란 */}
       <InputGroup>
         <Label htmlFor="name">이름</Label>
         <Input
-          type="text"
           onChange={handleNameInput}
           id="name"
-          placeholder="이름을 입력해 주세요."
+          placeholder="성함을 입력해 주세요."
+          $hasError={userNameError}
         />
       </InputGroup>
       <Animation $focus="true">

--- a/src/pages/main/Main.jsx
+++ b/src/pages/main/Main.jsx
@@ -88,7 +88,6 @@ function Main() {
   // 시작하기 클릭 시
   const handleClick = () => {
     if (!name) {
-      alert("성함을 입력해주세요.");
       setUserNameError(true);
       return;
     }

--- a/src/routes.jsx
+++ b/src/routes.jsx
@@ -95,6 +95,28 @@ const router = createBrowserRouter([
         ]
       },
       {
+        path: "melonticket",
+        element: <ProgressContents />,
+        children: [
+          {
+            path: "step0",
+            element: <ChallangeIntro />,
+            lable: "인트로"
+          }
+        ]
+      },
+      {
+        path: "ticketlink",
+        element: <ProgressContents />,
+        children: [
+          {
+            path: "step0",
+            element: <ChallangeIntro />,
+            lable: "인트로"
+          }
+        ]
+      },
+      {
         path: "yes24",
         element: <ProgressContents />,
         children: [

--- a/src/routes.jsx
+++ b/src/routes.jsx
@@ -33,7 +33,7 @@ const router = createBrowserRouter([
         children: [
           {
             path: "step0",
-            element: <Intro />,
+            element: <PrivateRoute element={<Intro />} />,
             label: "인트로 화면"
           },
           {
@@ -100,7 +100,7 @@ const router = createBrowserRouter([
         children: [
           {
             path: "step0",
-            element: <ChallangeIntro />,
+            element: <PrivateRoute element={<ChallangeIntro />} />,
             lable: "인트로"
           }
         ]
@@ -111,7 +111,7 @@ const router = createBrowserRouter([
         children: [
           {
             path: "step0",
-            element: <ChallangeIntro />,
+            element: <PrivateRoute element={<ChallangeIntro />} />,
             lable: "인트로"
           }
         ]
@@ -122,7 +122,7 @@ const router = createBrowserRouter([
         children: [
           {
             path: "step0",
-            element: <ChallangeIntro />,
+            element: <PrivateRoute element={<ChallangeIntro />} />,
             lable: "인트로"
           }
         ]

--- a/src/store/atom.js
+++ b/src/store/atom.js
@@ -75,13 +75,14 @@ export const practiceCountAtom = atomWithStorage("practiceCount", 0, storage);
 //좌석 매수 개수
 export const seatCountAtom = atomWithStorage("seatCount", 0, storage);
 
-//좌석 등급, 가격
+// 좌석 등급, 가격, 좌석 정보 상태
 export const seatInfoAtom = atomWithStorage(
   "seatInfo",
   {
     grade: "",
     price: 0,
-    date: ""
+    date: "",
+    seat: ""
   },
   storage
 );

--- a/src/store/atom.js
+++ b/src/store/atom.js
@@ -68,6 +68,8 @@ export const allowedSectionAtom = atomWithStorage(
 
 //사용자 이름
 export const userNameAtom = atomWithStorage("userName", "", storage);
+//사용자 이름 입력 상태 (userNameAtom이 존재하는가?)
+export const userNameErrorAtom = atom(false);
 
 //연습모드 완료 횟수
 export const practiceCountAtom = atomWithStorage("practiceCount", 0, storage);

--- a/src/util/getRandomSeat.js
+++ b/src/util/getRandomSeat.js
@@ -1,14 +1,17 @@
 import convertPriceToNumber from "./convertPriceToNumber";
+
 function getRandomSeat(poster) {
   const seatNames = Object.keys(poster.price);
-
   const randomIndex = Math.floor(Math.random() * seatNames.length);
-
   const randomSeat = seatNames[randomIndex];
-
   const randomPrice = convertPriceToNumber(poster.price[randomSeat]);
 
-  return { grade: randomSeat, price: randomPrice, date: poster.date };
+  return {
+    grade: randomSeat,
+    price: randomPrice,
+    date: poster.date[0],
+    seat: poster.seat
+  };
 }
 
 export default getRandomSeat;


### PR DESCRIPTION
## 📝작업 내용

### ✅ PrivateRoute 로 주소 이동 리디렉션
* PrivateRoute를 통해 userName이 없을 시 특정 주소 접근을 막고 홈 화면으로 리디렉션 되도록 설계
* 주소를 직접 작성하여 이동했을 때에도 접근 제한됨 
* 기존에는 세션스토리지를 직접 갖고왔으나, 마찬가지로 타이밍 이슈가 발생해서 전역 atom의 값을 갖고오도록 수정함

### ✅에러 처리 
* PrivateRoute는  주소 접근 제한 및 리디렉션만 담당, 에러 발생 시 alert()를 띄우거나 애니메이션을 주는 등 사용자와 추가적인 상호작용을 하는 코드는 작성이 불가능
* 따라서 아래 atom을 통해 userName이 있는지 없는지를 판단하도록 함
```javascript
//사용자 이름
export const userNameAtom = atomWithStorage("userName", "", storage);
//사용자 이름 입력 상태 (userNameAtom이 존재하는가?)
export const userNameErrorAtom = atom(false);
``` 
* header나 main의 시작하기 버튼을 통해 다음 화면에 접근할 때, userName이 없다면 userNameErroratom의 값이 true로 바뀌면서 사진에 나오는 Tooltip과 Input 빨간색 테두리 focus가 작동하도록 설계함

![ezgif-6-768a0375b1](https://github.com/user-attachments/assets/c073ac90-fd63-4beb-aaf5-9fba5766fd7d)

* 기존 Tooltip은 children요소에 focus 시에만 작동이 되는 것 같아, 그냥 간단한 Tooltip을 하나 더 생성함 (ErrorTooltip.jsx)
* alert()로 사용자와 상호작용하는 것보다 이 편이 어떤 에러가 발생했는지 인지하기  쉽고, UX가 개선될 것이라 판단함

## 💬리뷰 요구사항
* 지금 연습모드의 모든 단계를 alert()로 검증하고 있는데, form에 focus를 주거나 ErrorTooltip을 띄우는 방식으로 개선하는 것이 필요해 보임
* 백엔드 없이 프론트끼리 하는 프로젝트니, 좀 더 사용자 측면에 집중해서 사이트를 구성했다는 점이 돋보였음 좋겠음
* 다만 실전모드가 급하니 그걸 만들고 나서 디벨롭하는 과정으로 리팩토링 들어가보면 어떨까 싶음