### PR TITLE
Feat: PosterSection 구현 / 실전모드 step1 페이지 만들기

### DIFF
--- a/src/pages/challengeMode/components/PosterSection.jsx
+++ b/src/pages/challengeMode/components/PosterSection.jsx
@@ -1,0 +1,110 @@
+import React from "react";
+import styled from "styled-components";
+import Poster from "../../../components/poster/Poster";
+import { useAtom } from "jotai";
+import { postersAtom, levelAtom } from "../../../store/atom";
+import { formatDateRange } from "../../../util/date";
+
+// 전체 요소를 담는 컨테이너
+const PosterContainer = styled.div`
+  display: flex;
+  justify-content: flex-start;
+  align-items: flex-start;
+  flex-direction: row;
+  flex-shrink: 0;
+`;
+
+// 포스터 이미지만 담는 섹션
+const LeftSection = styled.div`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  margin-right: 20px;
+`;
+
+// 타이틀과 공연 정보를 담는 섹션
+const RightSection = styled.div`
+  display: flex;
+  flex-direction: column;
+  justify-content: flex-start;
+  align-items: flex-start;
+`;
+
+// 공연 제목
+const PosterTitle = styled.h2`
+  font-family: "pretendardB";
+  font-size: 24px;
+  margin-bottom: 20px;
+  align-self: flex-start;
+`;
+
+// 테이블 스타일
+const InfoTable = styled.table`
+  width: 100%;
+  border-collapse: collapse;
+  font-family: "pretendardR";
+  font-size: 16px;
+  padding: 4px 8px;
+  color: var(--text-color);
+`;
+
+const InfoRow = styled.tr``;
+
+const InfoLabel = styled.td`
+  padding: 8px;
+  font-weight: bold;
+`;
+
+const InfoValue = styled.td`
+  padding: 8px;
+`;
+
+const PosterSection = ({ id }) => {
+  const [posters] = useAtom(postersAtom);
+  const [level] = useAtom(levelAtom);
+  const poster = posters[id];
+
+  return (
+    <PosterContainer>
+      <LeftSection>
+        <Poster id={id} />
+      </LeftSection>
+      <RightSection>
+        <PosterTitle>{poster.title_ko}</PosterTitle>
+        <InfoTable>
+          <tbody>
+            <InfoRow>
+              <InfoLabel>장소</InfoLabel>
+              <InfoValue>{poster.venue}</InfoValue>
+            </InfoRow>
+            <InfoRow>
+              <InfoLabel>공연기간</InfoLabel>
+              <InfoValue>{formatDateRange(poster.date)}</InfoValue>
+            </InfoRow>
+            <InfoRow>
+              <InfoLabel>관람연령</InfoLabel>
+              <InfoValue>{poster.age}</InfoValue>
+            </InfoRow>
+            <InfoRow>
+              <InfoLabel>가격</InfoLabel>
+              <InfoValue>
+                <table>
+                  <tbody>
+                    {Object.entries(poster.price).map(([seatType, price]) => (
+                      <InfoRow key={seatType}>
+                        <InfoLabel>{seatType}</InfoLabel>
+                        <InfoValue>{price}</InfoValue>
+                      </InfoRow>
+                    ))}
+                  </tbody>
+                </table>
+              </InfoValue>
+            </InfoRow>
+          </tbody>
+        </InfoTable>
+      </RightSection>
+    </PosterContainer>
+  );
+};
+
+export default PosterSection;

--- a/src/pages/challengeMode/interpark/step1/PosterInterpark.jsx
+++ b/src/pages/challengeMode/interpark/step1/PosterInterpark.jsx
@@ -8,10 +8,9 @@ import { formatDateRange } from "../../../../util/date";
 // 전체 요소를 담는 컨테이너
 const PosterContainer = styled.div`
   display: flex;
-  justify-content: flex-start; /* 좌측 정렬 */
-  align-items: flex-start; /* 상단 정렬 */
+  justify-content: flex-start;
+  align-items: flex-start;
   flex-direction: row;
-
   flex-shrink: 0;
 `;
 

--- a/src/pages/challengeMode/interpark/step1/SelectRoundInterpark.jsx
+++ b/src/pages/challengeMode/interpark/step1/SelectRoundInterpark.jsx
@@ -7,8 +7,6 @@ import { useAtom } from "jotai";
 import {
   themeSiteAtom,
   selectedPosterAtom,
-  levelAtom,
-  progressAtom,
   postersAtom
 } from "../../../../store/atom";
 import { useNavigate } from "react-router-dom";
@@ -16,8 +14,8 @@ import formatTime from "../../../../util/time";
 
 const Container = styled.div`
   display: flex;
-  justify-content: space-between; /* 좌우로 공간 배분 */
-  align-items: flex-start; /* 상단 정렬 */
+  justify-content: space-between;
+  align-items: flex-start;
   padding: 20px 50px;
   width: 100%;
 `;
@@ -25,16 +23,16 @@ const Container = styled.div`
 const LeftSection = styled.div`
   display: flex;
   flex-direction: column;
-  justify-content: flex-start; /* 콘텐츠 상단 정렬 */
+  justify-content: flex-start;
   align-items: center;
 `;
 
 const RightSection = styled.div`
   display: flex;
   flex-direction: column;
-  justify-content: flex-start; /* 콘텐츠 상단 정렬 */
+  justify-content: flex-start;
   align-items: flex-start;
-  padding-left: 20px; /* 좌측 여백 추가 */
+  padding-left: 20px;
 `;
 
 const BoxWrapper = styled.div`
@@ -47,14 +45,12 @@ const BoxWrapper = styled.div`
 const RoundWrapper = styled.div`
   display: flex;
   flex-direction: column;
-  gap: 10px; /* 버튼 사이의 간격 추가 */
+  gap: 10px;
   width: 100%;
   padding-left: 20px;
 `;
 
 const SelectRoundInterpark = () => {
-  const [, setLevel] = useAtom(levelAtom);
-  const [, setProgress] = useAtom(progressAtom);
   const [selectedPoster] = useAtom(selectedPosterAtom);
   const [posters] = useAtom(postersAtom);
   const [posterId, setPosterId] = useState(0);
@@ -66,11 +62,9 @@ const SelectRoundInterpark = () => {
   const [, setThemeSite] = useAtom(themeSiteAtom);
 
   useEffect(() => {
-    setProgress(1);
     setThemeSite("interpark");
-    setLevel("high");
     setPosterId(0);
-  }, [setLevel, setProgress, selectedPoster, setThemeSite]);
+  }, [setThemeSite]);
 
   const poster = posters[posterId];
   const posterDates = poster ? poster.date : [];

--- a/src/pages/challengeMode/melonticket/step1/SelectRoundMelonticket.jsx
+++ b/src/pages/challengeMode/melonticket/step1/SelectRoundMelonticket.jsx
@@ -1,0 +1,161 @@
+import React, { useEffect, useState } from "react";
+import PosterSection from "../../components/PosterSection";
+import SelectCalender from "../../../../components/calender/SelectCalender";
+import Button from "../../../../components/button/Button";
+import styled from "styled-components";
+import { useAtomValue, useSetAtom } from "jotai";
+import {
+  themeSiteAtom,
+  selectedPosterAtom,
+  postersAtom
+} from "../../../../store/atom";
+import { useNavigate } from "react-router-dom";
+import formatTime from "../../../../util/time";
+
+const Container = styled.div`
+  display: flex;
+  flex-direction: column;
+  justify-content: flex-start;
+  align-items: center;
+  padding: 0 20vh;
+  box-sizing: border-box;
+`;
+
+const UpperSection = styled.div`
+  width: 100%;
+  display: flex;
+  justify-content: flex-start;
+  align-items: center;
+  margin-bottom: 30px;
+`;
+
+const LowerSection = styled.div`
+  width: 100%;
+  display: flex;
+  flex-direction: row;
+  gap: 30px;
+  justify-content: flex-start;
+  align-items: flex-start;
+`;
+
+const BoxWrapper = styled.div`
+  width: auto;
+  border: 1px solid var(--fill-color);
+  padding: 20px;
+  border-radius: 8px;
+  gap: 10px;
+  display: flex;
+  flex-direction: row;
+`;
+
+const TitleText = styled.p`
+  font-size: 18px;
+  white-space: nowrap; // 글자 크기 고정
+  margin: 0;
+`;
+
+const ButtonSection = styled.div`
+  width: 100%;
+  display: flex;
+  padding-top: 20px;
+  justify-content: flex-end;
+`;
+
+const SelectRoundMelonticket = () => {
+  const selectedPoster = useAtomValue(selectedPosterAtom);
+  const posters = useAtomValue(postersAtom);
+  const [posterId, setPosterId] = useState(0);
+  const [dateSelected, setDateSelected] = useState(false);
+  const [roundSelected, setRoundSelected] = useState(false);
+  const [timesButtons, setTimesButtons] = useState([]);
+  const [correctRound, setCorrectRound] = useState(null);
+  const navigate = useNavigate();
+  const setThemeSite = useSetAtom(themeSiteAtom);
+
+  useEffect(() => {
+    setThemeSite("melonticket");
+    setPosterId(1);
+  }, [setThemeSite]);
+
+  const poster = posters[posterId];
+  const posterDates = poster?.date || [];
+  const posterTimes = poster?.time || {};
+
+  const handleDateSelect = (formattedDate) => {
+    const correctDate = posterDates[0];
+    if (formattedDate === correctDate) {
+      setDateSelected(true);
+      const timesArray = formatTime(posterTimes, formattedDate);
+      setTimesButtons(timesArray);
+      if (timesArray.length > 0) {
+        setCorrectRound(timesArray[0]);
+      }
+    } else {
+      alert("날짜를 다시 선택해주세요.");
+    }
+  };
+
+  const handleRoundClick = (time) => {
+    if (!dateSelected) {
+      alert("먼저 올바른 날짜를 선택해주세요.");
+      return;
+    }
+    if (time === correctRound) {
+      alert(`${time}으로 공연을 예매합니다.`);
+      setRoundSelected(true);
+    } else {
+      alert("회차를 다시 선택해주세요.");
+    }
+  };
+
+  const handleReserveClick = () => {
+    if (!roundSelected) {
+      alert("먼저 회차를 선택해주세요.");
+      return;
+    }
+    navigate("/challenge/melonticket/step2");
+  };
+
+  return (
+    <Container>
+      <UpperSection>
+        <PosterSection id={posterId} />
+      </UpperSection>
+      <LowerSection>
+        <BoxWrapper>
+          <TitleText>날짜 선택</TitleText>
+          <SelectCalender
+            onDateSelect={handleDateSelect}
+            initialDate={
+              posterDates.length > 0 ? new Date(posterDates[0]) : new Date()
+            }
+          />
+        </BoxWrapper>
+        <BoxWrapper>
+          <TitleText>회차 선택</TitleText>
+          {timesButtons.length > 0 ? (
+            timesButtons.map((time, index) => (
+              <Button
+                key={index}
+                text={`${index + 1}회 - ${time}`}
+                type="outline"
+                onClick={() => handleRoundClick(time)}
+              />
+            ))
+          ) : (
+            <Button
+              text="날짜 선택 후 확인"
+              type="outline"
+              onClick={() => alert("날짜를 먼저 선택해주세요.")}
+            />
+          )}
+        </BoxWrapper>
+      </LowerSection>
+      <ButtonSection>
+        <Button text="인증 후 예매하기" onClick={handleReserveClick} />
+      </ButtonSection>
+    </Container>
+  );
+};
+
+export default SelectRoundMelonticket;

--- a/src/pages/challengeMode/ticketlink/step1/SelectRoundTicketlink.jsx
+++ b/src/pages/challengeMode/ticketlink/step1/SelectRoundTicketlink.jsx
@@ -1,0 +1,161 @@
+import React, { useEffect, useState } from "react";
+import PosterSection from "../../components/PosterSection";
+import SelectCalender from "../../../../components/calender/SelectCalender";
+import Button from "../../../../components/button/Button";
+import styled from "styled-components";
+import { useAtomValue, useSetAtom } from "jotai";
+import {
+  themeSiteAtom,
+  selectedPosterAtom,
+  postersAtom
+} from "../../../../store/atom";
+import { useNavigate } from "react-router-dom";
+import formatTime from "../../../../util/time";
+
+const Container = styled.div`
+  display: flex;
+  flex-direction: column;
+  justify-content: flex-start;
+  align-items: center;
+  padding: 0 20vh;
+  box-sizing: border-box;
+`;
+
+const UpperSection = styled.div`
+  width: 100%;
+  display: flex;
+  justify-content: flex-start;
+  align-items: center;
+  margin-bottom: 30px;
+`;
+
+const LowerSection = styled.div`
+  width: 100%;
+  display: flex;
+  flex-direction: row;
+  gap: 30px;
+  justify-content: flex-start;
+  align-items: flex-start;
+`;
+
+const BoxWrapper = styled.div`
+  width: auto;
+  border: 1px solid var(--fill-color);
+  padding: 20px;
+  border-radius: 8px;
+  gap: 10px;
+  display: flex;
+  flex-direction: row;
+`;
+
+const TitleText = styled.p`
+  font-size: 18px;
+  white-space: nowrap; // 글자 크기 고정
+  margin: 0;
+`;
+
+const ButtonSection = styled.div`
+  width: 100%;
+  display: flex;
+  padding-top: 20px;
+  justify-content: flex-end;
+`;
+
+const SelectRoundTicketlink = () => {
+  const selectedPoster = useAtomValue(selectedPosterAtom);
+  const posters = useAtomValue(postersAtom);
+  const [posterId, setPosterId] = useState(0);
+  const [dateSelected, setDateSelected] = useState(false);
+  const [roundSelected, setRoundSelected] = useState(false);
+  const [timesButtons, setTimesButtons] = useState([]);
+  const [correctRound, setCorrectRound] = useState(null);
+  const navigate = useNavigate();
+  const setThemeSite = useSetAtom(themeSiteAtom);
+
+  useEffect(() => {
+    setThemeSite("ticketlink");
+    setPosterId(2);
+  }, [setThemeSite]);
+
+  const poster = posters[posterId];
+  const posterDates = poster?.date || [];
+  const posterTimes = poster?.time || {};
+
+  const handleDateSelect = (formattedDate) => {
+    const correctDate = posterDates[0];
+    if (formattedDate === correctDate) {
+      setDateSelected(true);
+      const timesArray = formatTime(posterTimes, formattedDate);
+      setTimesButtons(timesArray);
+      if (timesArray.length > 0) {
+        setCorrectRound(timesArray[0]);
+      }
+    } else {
+      alert("날짜를 다시 선택해주세요.");
+    }
+  };
+
+  const handleRoundClick = (time) => {
+    if (!dateSelected) {
+      alert("먼저 올바른 날짜를 선택해주세요.");
+      return;
+    }
+    if (time === correctRound) {
+      alert(`${time}으로 공연을 예매합니다.`);
+      setRoundSelected(true);
+    } else {
+      alert("회차를 다시 선택해주세요.");
+    }
+  };
+
+  const handleReserveClick = () => {
+    if (!roundSelected) {
+      alert("먼저 회차를 선택해주세요.");
+      return;
+    }
+    navigate("/challenge/ticketlink/step2");
+  };
+
+  return (
+    <Container>
+      <UpperSection>
+        <PosterSection id={posterId} />
+      </UpperSection>
+      <LowerSection>
+        <BoxWrapper>
+          <TitleText>날짜 선택</TitleText>
+          <SelectCalender
+            onDateSelect={handleDateSelect}
+            initialDate={
+              posterDates.length > 0 ? new Date(posterDates[0]) : new Date()
+            }
+          />
+        </BoxWrapper>
+        <BoxWrapper>
+          <TitleText>회차 선택</TitleText>
+          {timesButtons.length > 0 ? (
+            timesButtons.map((time, index) => (
+              <Button
+                key={index}
+                text={`${index + 1}회 - ${time}`}
+                type="outline"
+                onClick={() => handleRoundClick(time)}
+              />
+            ))
+          ) : (
+            <Button
+              text="날짜 선택 후 확인"
+              type="outline"
+              onClick={() => alert("날짜를 먼저 선택해주세요.")}
+            />
+          )}
+        </BoxWrapper>
+      </LowerSection>
+      <ButtonSection>
+        <Button text="인증 후 예매하기" onClick={handleReserveClick} />
+      </ButtonSection>
+    </Container>
+  );
+};
+
+export default SelectRoundTicketlink;

--- a/src/pages/challengeMode/yes24/step1/SelectRoundYes24.jsx
+++ b/src/pages/challengeMode/yes24/step1/SelectRoundYes24.jsx
@@ -1,0 +1,161 @@
+import React, { useEffect, useState } from "react";
+import PosterSection from "../../components/PosterSection";
+import SelectCalender from "../../../../components/calender/SelectCalender";
+import Button from "../../../../components/button/Button";
+import styled from "styled-components";
+import { useAtomValue, useSetAtom } from "jotai";
+import {
+  themeSiteAtom,
+  selectedPosterAtom,
+  postersAtom
+} from "../../../../store/atom";
+import { useNavigate } from "react-router-dom";
+import formatTime from "../../../../util/time";
+
+const Container = styled.div`
+  display: flex;
+  flex-direction: column;
+  justify-content: flex-start;
+  align-items: center;
+  padding: 0 20vh;
+  box-sizing: border-box;
+`;
+
+const UpperSection = styled.div`
+  width: 100%;
+  display: flex;
+  justify-content: flex-start;
+  align-items: center;
+  margin-bottom: 30px;
+`;
+
+const LowerSection = styled.div`
+  width: 100%;
+  display: flex;
+  flex-direction: row;
+  gap: 30px;
+  justify-content: flex-start;
+  align-items: flex-start;
+`;
+
+const BoxWrapper = styled.div`
+  width: auto;
+  border: 1px solid var(--fill-color);
+  padding: 20px;
+  border-radius: 8px;
+  gap: 10px;
+  display: flex;
+  flex-direction: row;
+`;
+
+const TitleText = styled.p`
+  font-size: 18px;
+  white-space: nowrap; // 글자 크기 고정
+  margin: 0;
+`;
+
+const ButtonSection = styled.div`
+  width: 100%;
+  display: flex;
+  padding-top: 20px;
+  justify-content: flex-end;
+`;
+
+const SelectRoundYes24 = () => {
+  const selectedPoster = useAtomValue(selectedPosterAtom);
+  const posters = useAtomValue(postersAtom);
+  const [posterId, setPosterId] = useState(0);
+  const [dateSelected, setDateSelected] = useState(false);
+  const [roundSelected, setRoundSelected] = useState(false);
+  const [timesButtons, setTimesButtons] = useState([]);
+  const [correctRound, setCorrectRound] = useState(null);
+  const navigate = useNavigate();
+  const setThemeSite = useSetAtom(themeSiteAtom);
+
+  useEffect(() => {
+    setThemeSite("yes24");
+    setPosterId(3);
+  }, [setThemeSite]);
+
+  const poster = posters[posterId];
+  const posterDates = poster?.date || [];
+  const posterTimes = poster?.time || {};
+
+  const handleDateSelect = (formattedDate) => {
+    const correctDate = posterDates[0];
+    if (formattedDate === correctDate) {
+      setDateSelected(true);
+      const timesArray = formatTime(posterTimes, formattedDate);
+      setTimesButtons(timesArray);
+      if (timesArray.length > 0) {
+        setCorrectRound(timesArray[0]);
+      }
+    } else {
+      alert("날짜를 다시 선택해주세요.");
+    }
+  };
+
+  const handleRoundClick = (time) => {
+    if (!dateSelected) {
+      alert("먼저 올바른 날짜를 선택해주세요.");
+      return;
+    }
+    if (time === correctRound) {
+      alert(`${time}으로 공연을 예매합니다.`);
+      setRoundSelected(true);
+    } else {
+      alert("회차를 다시 선택해주세요.");
+    }
+  };
+
+  const handleReserveClick = () => {
+    if (!roundSelected) {
+      alert("먼저 회차를 선택해주세요.");
+      return;
+    }
+    navigate("/challenge/yes24/step2");
+  };
+
+  return (
+    <Container>
+      <UpperSection>
+        <PosterSection id={posterId} />
+      </UpperSection>
+      <LowerSection>
+        <BoxWrapper>
+          <TitleText>날짜 선택</TitleText>
+          <SelectCalender
+            onDateSelect={handleDateSelect}
+            initialDate={
+              posterDates.length > 0 ? new Date(posterDates[0]) : new Date()
+            }
+          />
+        </BoxWrapper>
+        <BoxWrapper>
+          <TitleText>회차 선택</TitleText>
+          {timesButtons.length > 0 ? (
+            timesButtons.map((time, index) => (
+              <Button
+                key={index}
+                text={`${index + 1}회 - ${time}`}
+                type="outline"
+                onClick={() => handleRoundClick(time)}
+              />
+            ))
+          ) : (
+            <Button
+              text="날짜 선택 후 확인"
+              type="outline"
+              onClick={() => alert("날짜를 먼저 선택해주세요.")}
+            />
+          )}
+        </BoxWrapper>
+      </LowerSection>
+      <ButtonSection>
+        <Button text="인증 후 예매하기" onClick={handleReserveClick} />
+      </ButtonSection>
+    </Container>
+  );
+};
+
+export default SelectRoundYes24;

--- a/src/routes.jsx
+++ b/src/routes.jsx
@@ -14,6 +14,9 @@ import ChallangeIntro from "./pages/challengeMode/intro/ChallangeIntro";
 import SelectPerformance from "./pages/practiceMode/step1/SelectPerformance";
 import SelectRound from "./pages/practiceMode/step1/SelectRound";
 import SelectRoundInterpark from "./pages/challengeMode/interpark/step1/SelectRoundInterpark";
+import SelectRoundMelonticket from "./pages/challengeMode/melonticket/step1/SelectRoundMelonticket";
+import SelectRoundTicketlink from "./pages/challengeMode/ticketlink/step1/SelectRoundTicketlink";
+import SelectRoundYes24 from "./pages/challengeMode/yes24/step1/SelectRoundYes24";
 // step 2
 import SelectSeat from "./pages/practiceMode/step2/SelectSeat";
 import SelectSeatInterpark from "./pages/challengeMode/interpark/step2/SelectSeatInterpark";
@@ -133,6 +136,11 @@ const router = createBrowserRouter([
                 path: "step0",
                 element: <PrivateRoute element={<ChallangeIntro />} />,
                 lable: "인트로"
+              },
+              {
+                path: "step1",
+                element: <PrivateRoute element={<SelectRoundMelonticket />} />,
+                label: "날짜 및 회차 선택"
               }
             ]
           },
@@ -144,6 +152,11 @@ const router = createBrowserRouter([
                 path: "step0",
                 element: <PrivateRoute element={<ChallangeIntro />} />,
                 lable: "인트로"
+              },
+              {
+                path: "step1",
+                element: <PrivateRoute element={<SelectRoundTicketlink />} />,
+                label: "날짜 및 회차 선택"
               }
             ]
           },
@@ -155,6 +168,11 @@ const router = createBrowserRouter([
                 path: "step0",
                 element: <PrivateRoute element={<ChallangeIntro />} />,
                 lable: "인트로"
+              },
+              {
+                path: "step1",
+                element: <PrivateRoute element={<SelectRoundYes24 />} />,
+                label: "날짜 및 회차 선택"
               }
             ]
           }


### PR DESCRIPTION
# 📝작업 내용
### ✅ `PosterSection.jsx` 구현
   - `PosterInterpark`와 마찬가지로, PosterInfo를 리팩토링하여 만듦.
   - 실전모드의 멜론티켓, 티켓링크, Yes24 step1 페이지에서 공연 정보를 나타내기 위해 사용함.

###  ✅ 실전모드 step1 페이지 구현 
-  ...step1/SelectRound[$themeSite] <- 해당 경로에 만들어둠
- level, progress 상태를 해당 페이지에서 다시 set하지 않도록 변경함
  -  사이트 선택 페이지(`SelectSite.jsx`)에서 navigate할 때 난이도를 고급으로 설정하도록 변경.
  - 이렇게 바꾼 이유: useSetAtom을 최대한 중복 사용하지 않도록 하기 위해!

## 스크린샷 (선택)
- 멜론티켓
![2024-08-25 00 52 22](https://github.com/user-attachments/assets/631b948c-3697-4c62-8179-445a2071de35)
- yes24
![2024-08-25 00 50 10](https://github.com/user-attachments/assets/5f9374ec-ccf8-4667-8d96-88cfe864c52e)

## 💬리뷰 요구사항
고급 난이도처럼 SelectPerformance 단계를 추가하는게 좋을까?
지금은 공연이 정해져 있으니까 좀 더 난이도를 올리면 좋을 것 같아서...🙂
만약 공연 선택 단계를 추가한다면 PosterList.jsx, poster.json을 사이트마다 다시 만들어야 할 것 같아!

