### PR TITLE
Feat: 실전 모드 Step5 및 기록 페이지를 위한 파이어베이스 설정 테스트

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,6 @@ dist-ssr
 *.sw?
 
 .eslintcache
+
+# Firebase
+.env

--- a/firebase-config.js
+++ b/firebase-config.js
@@ -1,0 +1,20 @@
+import { initializeApp } from "firebase/app";
+import { getAnalytics } from "firebase/analytics";
+import { getFirestore } from "firebase/firestore";
+
+// console.log("환경 변수 적용 테스트:", import.meta.env.VITE_API_KEY);
+
+const firebaseConfig = {
+  apiKey: import.meta.env.VITE_API_KEY,
+  authDomain: import.meta.env.VITE_AUTH_DOMAIN,
+  projectId: import.meta.env.VITE_PROJECT_ID,
+  storageBucket: import.meta.env.VITE_STORAGE_BUCKET,
+  messagingSenderId: import.meta.env.VITE_MESSAGING_SENDER_ID,
+  appId: import.meta.env.VITE_APP_ID,
+  measurementId: import.meta.env.VITE_MEASUREMENT_ID
+};
+
+// 파이어베이스 초기화
+const app = initializeApp(firebaseConfig);
+const analytics = getAnalytics(app);
+export const db = getFirestore(app);

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.0",
       "hasInstallScript": true,
       "dependencies": {
+        "firebase": "^10.13.0",
         "jotai": "^2.9.0",
         "react": "^18.3.1",
         "react-calendar": "^5.0.0",
@@ -901,6 +902,562 @@
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
     },
+    "node_modules/@fastify/busboy": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@fastify/busboy/-/busboy-2.1.1.tgz",
+      "integrity": "sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@firebase/analytics": {
+      "version": "0.10.7",
+      "resolved": "https://registry.npmjs.org/@firebase/analytics/-/analytics-0.10.7.tgz",
+      "integrity": "sha512-GE29uTT6y/Jv2EP0OjpTezeTQZ5FTCTaZXKrrdVGjb/t35AU4u/jiU+hUwUPpuK8fqhhiHkS/AawE3a3ZK/a9Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.6.8",
+        "@firebase/installations": "0.6.8",
+        "@firebase/logger": "0.4.2",
+        "@firebase/util": "1.9.7",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "@firebase/app": "0.x"
+      }
+    },
+    "node_modules/@firebase/analytics-compat": {
+      "version": "0.2.13",
+      "resolved": "https://registry.npmjs.org/@firebase/analytics-compat/-/analytics-compat-0.2.13.tgz",
+      "integrity": "sha512-aZ4wGfNDMsCxhKzDbK2g1aV0JKsdQ9FbeIsjpNJPzhahV0XYj+z36Y4RNLPpG/6hHU4gxnezxs+yn3HhHkNL8w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/analytics": "0.10.7",
+        "@firebase/analytics-types": "0.8.2",
+        "@firebase/component": "0.6.8",
+        "@firebase/util": "1.9.7",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "@firebase/app-compat": "0.x"
+      }
+    },
+    "node_modules/@firebase/analytics-types": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/@firebase/analytics-types/-/analytics-types-0.8.2.tgz",
+      "integrity": "sha512-EnzNNLh+9/sJsimsA/FGqzakmrAUKLeJvjRHlg8df1f97NLUlFidk9600y0ZgWOp3CAxn6Hjtk+08tixlUOWyw==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@firebase/app": {
+      "version": "0.10.9",
+      "resolved": "https://registry.npmjs.org/@firebase/app/-/app-0.10.9.tgz",
+      "integrity": "sha512-AmGlPg/4SoDhwCdvVDeZsN5Yn+czYD/m/NAEOOCOhwn3Cz1xmEFKAKcyZKKahLrh5QPmge5Adyw+sk3cBTubBg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.6.8",
+        "@firebase/logger": "0.4.2",
+        "@firebase/util": "1.9.7",
+        "idb": "7.1.1",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@firebase/app-check": {
+      "version": "0.8.7",
+      "resolved": "https://registry.npmjs.org/@firebase/app-check/-/app-check-0.8.7.tgz",
+      "integrity": "sha512-EkOeJcMKVR0zZ6z/jqcFTqHb/xq+TVIRIuBNGHdpcIuFU1czhSlegvqv2+nC+nFrkD8M6Xvd3tAlUOkdbMeS6A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.6.8",
+        "@firebase/logger": "0.4.2",
+        "@firebase/util": "1.9.7",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "@firebase/app": "0.x"
+      }
+    },
+    "node_modules/@firebase/app-check-compat": {
+      "version": "0.3.14",
+      "resolved": "https://registry.npmjs.org/@firebase/app-check-compat/-/app-check-compat-0.3.14.tgz",
+      "integrity": "sha512-kK3bPfojAfXE53W+20rxMqIxrloFswXG9vh4kEdYL6Wa2IB3sD5++2dPiK3yGxl8oQiqS8qL2wcKB5/xLpEVEg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/app-check": "0.8.7",
+        "@firebase/app-check-types": "0.5.2",
+        "@firebase/component": "0.6.8",
+        "@firebase/logger": "0.4.2",
+        "@firebase/util": "1.9.7",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "@firebase/app-compat": "0.x"
+      }
+    },
+    "node_modules/@firebase/app-check-interop-types": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/@firebase/app-check-interop-types/-/app-check-interop-types-0.3.2.tgz",
+      "integrity": "sha512-LMs47Vinv2HBMZi49C09dJxp0QT5LwDzFaVGf/+ITHe3BlIhUiLNttkATSXplc89A2lAaeTqjgqVkiRfUGyQiQ==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@firebase/app-check-types": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/@firebase/app-check-types/-/app-check-types-0.5.2.tgz",
+      "integrity": "sha512-FSOEzTzL5bLUbD2co3Zut46iyPWML6xc4x+78TeaXMSuJap5QObfb+rVvZJtla3asN4RwU7elaQaduP+HFizDA==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@firebase/app-compat": {
+      "version": "0.2.39",
+      "resolved": "https://registry.npmjs.org/@firebase/app-compat/-/app-compat-0.2.39.tgz",
+      "integrity": "sha512-NnTFywe+M/jxZn751NIEhidgDePiDvlcfabvGxBy4YbU1E+b0TpEuJUnm3L6YDZtaZLVEz8ieoq9wbJkgGZ2rg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/app": "0.10.9",
+        "@firebase/component": "0.6.8",
+        "@firebase/logger": "0.4.2",
+        "@firebase/util": "1.9.7",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@firebase/app-types": {
+      "version": "0.9.2",
+      "resolved": "https://registry.npmjs.org/@firebase/app-types/-/app-types-0.9.2.tgz",
+      "integrity": "sha512-oMEZ1TDlBz479lmABwWsWjzHwheQKiAgnuKxE0pz0IXCVx7/rtlkx1fQ6GfgK24WCrxDKMplZrT50Kh04iMbXQ==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@firebase/auth": {
+      "version": "1.7.7",
+      "resolved": "https://registry.npmjs.org/@firebase/auth/-/auth-1.7.7.tgz",
+      "integrity": "sha512-gMB0uRRNiIvYorEDLtIq1mc7x5D080EsoghTIph9xnbLqcQS3qRBREEC2o21nMEhviAeiGJMelRkKhAkkggjmA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.6.8",
+        "@firebase/logger": "0.4.2",
+        "@firebase/util": "1.9.7",
+        "tslib": "^2.1.0",
+        "undici": "5.28.4"
+      },
+      "peerDependencies": {
+        "@firebase/app": "0.x",
+        "@react-native-async-storage/async-storage": "^1.18.1"
+      },
+      "peerDependenciesMeta": {
+        "@react-native-async-storage/async-storage": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@firebase/auth-compat": {
+      "version": "0.5.12",
+      "resolved": "https://registry.npmjs.org/@firebase/auth-compat/-/auth-compat-0.5.12.tgz",
+      "integrity": "sha512-K47inLqjTREez85D7pP0TmRv5aQcap22cJW67poLwJoJ6BVVH0I2NOfIoMqENetCrgGS+7vXSIZaLjvHFHwS+g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/auth": "1.7.7",
+        "@firebase/auth-types": "0.12.2",
+        "@firebase/component": "0.6.8",
+        "@firebase/util": "1.9.7",
+        "tslib": "^2.1.0",
+        "undici": "5.28.4"
+      },
+      "peerDependencies": {
+        "@firebase/app-compat": "0.x"
+      }
+    },
+    "node_modules/@firebase/auth-interop-types": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/@firebase/auth-interop-types/-/auth-interop-types-0.2.3.tgz",
+      "integrity": "sha512-Fc9wuJGgxoxQeavybiuwgyi+0rssr76b+nHpj+eGhXFYAdudMWyfBHvFL/I5fEHniUM/UQdFzi9VXJK2iZF7FQ==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@firebase/auth-types": {
+      "version": "0.12.2",
+      "resolved": "https://registry.npmjs.org/@firebase/auth-types/-/auth-types-0.12.2.tgz",
+      "integrity": "sha512-qsEBaRMoGvHO10unlDJhaKSuPn4pyoTtlQuP1ghZfzB6rNQPuhp/N/DcFZxm9i4v0SogjCbf9reWupwIvfmH6w==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "@firebase/app-types": "0.x",
+        "@firebase/util": "1.x"
+      }
+    },
+    "node_modules/@firebase/component": {
+      "version": "0.6.8",
+      "resolved": "https://registry.npmjs.org/@firebase/component/-/component-0.6.8.tgz",
+      "integrity": "sha512-LcNvxGLLGjBwB0dJUsBGCej2fqAepWyBubs4jt1Tiuns7QLbXHuyObZ4aMeBjZjWx4m8g1LoVI9QFpSaq/k4/g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/util": "1.9.7",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@firebase/database": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/@firebase/database/-/database-1.0.7.tgz",
+      "integrity": "sha512-wjXr5AO8RPxVVg7rRCYffT7FMtBjHRfJ9KMwi19MbOf0vBf0H9YqW3WCgcnLpXI6ehiUcU3z3qgPnnU0nK6SnA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/app-check-interop-types": "0.3.2",
+        "@firebase/auth-interop-types": "0.2.3",
+        "@firebase/component": "0.6.8",
+        "@firebase/logger": "0.4.2",
+        "@firebase/util": "1.9.7",
+        "faye-websocket": "0.11.4",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@firebase/database-compat": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/@firebase/database-compat/-/database-compat-1.0.7.tgz",
+      "integrity": "sha512-R/3B+VVzEFN5YcHmfWns3eitA8fHLTL03io+FIoMcTYkajFnrBdS3A+g/KceN9omP7FYYYGTQWF9lvbEx6eMEg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.6.8",
+        "@firebase/database": "1.0.7",
+        "@firebase/database-types": "1.0.4",
+        "@firebase/logger": "0.4.2",
+        "@firebase/util": "1.9.7",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@firebase/database-types": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@firebase/database-types/-/database-types-1.0.4.tgz",
+      "integrity": "sha512-mz9ZzbH6euFXbcBo+enuJ36I5dR5w+enJHHjy9Y5ThCdKUseqfDjW3vCp1YxE9zygFCSjJJ/z1cQ+zodvUcwPQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/app-types": "0.9.2",
+        "@firebase/util": "1.9.7"
+      }
+    },
+    "node_modules/@firebase/firestore": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/@firebase/firestore/-/firestore-4.7.0.tgz",
+      "integrity": "sha512-wGOp84P1qa1pfpdct6lckfyowTuvIlUDHoiRcN8dFDT4WnZDh0tZW1X77SMiBUVejK8xIRLBCK3yDTejlRVrUA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.6.8",
+        "@firebase/logger": "0.4.2",
+        "@firebase/util": "1.9.7",
+        "@firebase/webchannel-wrapper": "1.0.1",
+        "@grpc/grpc-js": "~1.9.0",
+        "@grpc/proto-loader": "^0.7.8",
+        "tslib": "^2.1.0",
+        "undici": "5.28.4"
+      },
+      "engines": {
+        "node": ">=10.10.0"
+      },
+      "peerDependencies": {
+        "@firebase/app": "0.x"
+      }
+    },
+    "node_modules/@firebase/firestore-compat": {
+      "version": "0.3.35",
+      "resolved": "https://registry.npmjs.org/@firebase/firestore-compat/-/firestore-compat-0.3.35.tgz",
+      "integrity": "sha512-VdYQtMIrPjsgZpuBwvry6LgcS0vbUhHzpebaKm5oc9oTTvP4K7oxvR/ZJdDjIE5rBugn1SdY++uGMatcIvBkZg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.6.8",
+        "@firebase/firestore": "4.7.0",
+        "@firebase/firestore-types": "3.0.2",
+        "@firebase/util": "1.9.7",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "@firebase/app-compat": "0.x"
+      }
+    },
+    "node_modules/@firebase/firestore-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@firebase/firestore-types/-/firestore-types-3.0.2.tgz",
+      "integrity": "sha512-wp1A+t5rI2Qc/2q7r2ZpjUXkRVPtGMd6zCLsiWurjsQpqPgFin3AhNibKcIzoF2rnToNa/XYtyWXuifjOOwDgg==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "@firebase/app-types": "0.x",
+        "@firebase/util": "1.x"
+      }
+    },
+    "node_modules/@firebase/functions": {
+      "version": "0.11.6",
+      "resolved": "https://registry.npmjs.org/@firebase/functions/-/functions-0.11.6.tgz",
+      "integrity": "sha512-GPfIBPtpwQvsC7SQbgaUjLTdja0CsNwMoKSgrzA1FGGRk4NX6qO7VQU6XCwBiAFWbpbQex6QWkSMsCzLx1uibQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/app-check-interop-types": "0.3.2",
+        "@firebase/auth-interop-types": "0.2.3",
+        "@firebase/component": "0.6.8",
+        "@firebase/messaging-interop-types": "0.2.2",
+        "@firebase/util": "1.9.7",
+        "tslib": "^2.1.0",
+        "undici": "5.28.4"
+      },
+      "peerDependencies": {
+        "@firebase/app": "0.x"
+      }
+    },
+    "node_modules/@firebase/functions-compat": {
+      "version": "0.3.12",
+      "resolved": "https://registry.npmjs.org/@firebase/functions-compat/-/functions-compat-0.3.12.tgz",
+      "integrity": "sha512-r3XUb5VlITWpML46JymfJPkK6I9j4SNlO7qWIXUc0TUmkv0oAfVoiIt1F83/NuMZXaGr4YWA/794nVSy4GV8tw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.6.8",
+        "@firebase/functions": "0.11.6",
+        "@firebase/functions-types": "0.6.2",
+        "@firebase/util": "1.9.7",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "@firebase/app-compat": "0.x"
+      }
+    },
+    "node_modules/@firebase/functions-types": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/@firebase/functions-types/-/functions-types-0.6.2.tgz",
+      "integrity": "sha512-0KiJ9lZ28nS2iJJvimpY4nNccV21rkQyor5Iheu/nq8aKXJqtJdeSlZDspjPSBBiHRzo7/GMUttegnsEITqR+w==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@firebase/installations": {
+      "version": "0.6.8",
+      "resolved": "https://registry.npmjs.org/@firebase/installations/-/installations-0.6.8.tgz",
+      "integrity": "sha512-57V374qdb2+wT5v7+ntpLXBjZkO6WRgmAUbVkRfFTM/4t980p0FesbqTAcOIiM8U866UeuuuF8lYH70D3jM/jQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.6.8",
+        "@firebase/util": "1.9.7",
+        "idb": "7.1.1",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "@firebase/app": "0.x"
+      }
+    },
+    "node_modules/@firebase/installations-compat": {
+      "version": "0.2.8",
+      "resolved": "https://registry.npmjs.org/@firebase/installations-compat/-/installations-compat-0.2.8.tgz",
+      "integrity": "sha512-pI2q8JFHB7yIq/szmhzGSWXtOvtzl6tCUmyykv5C8vvfOVJUH6mP4M4iwjbK8S1JotKd/K70+JWyYlxgQ0Kpyw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.6.8",
+        "@firebase/installations": "0.6.8",
+        "@firebase/installations-types": "0.5.2",
+        "@firebase/util": "1.9.7",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "@firebase/app-compat": "0.x"
+      }
+    },
+    "node_modules/@firebase/installations-types": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/@firebase/installations-types/-/installations-types-0.5.2.tgz",
+      "integrity": "sha512-que84TqGRZJpJKHBlF2pkvc1YcXrtEDOVGiDjovP/a3s6W4nlbohGXEsBJo0JCeeg/UG9A+DEZVDUV9GpklUzA==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "@firebase/app-types": "0.x"
+      }
+    },
+    "node_modules/@firebase/logger": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/@firebase/logger/-/logger-0.4.2.tgz",
+      "integrity": "sha512-Q1VuA5M1Gjqrwom6I6NUU4lQXdo9IAQieXlujeHZWvRt1b7qQ0KwBaNAjgxG27jgF9/mUwsNmO8ptBCGVYhB0A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@firebase/messaging": {
+      "version": "0.12.10",
+      "resolved": "https://registry.npmjs.org/@firebase/messaging/-/messaging-0.12.10.tgz",
+      "integrity": "sha512-fGbxJPKpl2DIKNJGhbk4mYPcM+qE2gl91r6xPoiol/mN88F5Ym6UeRdMVZah+pijh9WxM55alTYwXuW40r1Y2Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.6.8",
+        "@firebase/installations": "0.6.8",
+        "@firebase/messaging-interop-types": "0.2.2",
+        "@firebase/util": "1.9.7",
+        "idb": "7.1.1",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "@firebase/app": "0.x"
+      }
+    },
+    "node_modules/@firebase/messaging-compat": {
+      "version": "0.2.10",
+      "resolved": "https://registry.npmjs.org/@firebase/messaging-compat/-/messaging-compat-0.2.10.tgz",
+      "integrity": "sha512-FXQm7rcowkDm8kFLduHV35IRYCRo+Ng0PIp/t1+EBuEbyplaKkGjZ932pE+owf/XR+G/60ku2QRBptRGLXZydg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.6.8",
+        "@firebase/messaging": "0.12.10",
+        "@firebase/util": "1.9.7",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "@firebase/app-compat": "0.x"
+      }
+    },
+    "node_modules/@firebase/messaging-interop-types": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/@firebase/messaging-interop-types/-/messaging-interop-types-0.2.2.tgz",
+      "integrity": "sha512-l68HXbuD2PPzDUOFb3aG+nZj5KA3INcPwlocwLZOzPp9rFM9yeuI9YLl6DQfguTX5eAGxO0doTR+rDLDvQb5tA==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@firebase/performance": {
+      "version": "0.6.8",
+      "resolved": "https://registry.npmjs.org/@firebase/performance/-/performance-0.6.8.tgz",
+      "integrity": "sha512-F+alziiIZ6Yn8FG47mxwljq+4XkgkT2uJIFRlkyViUQRLzrogaUJW6u/+6ZrePXnouKlKIwzqos3PVJraPEcCA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.6.8",
+        "@firebase/installations": "0.6.8",
+        "@firebase/logger": "0.4.2",
+        "@firebase/util": "1.9.7",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "@firebase/app": "0.x"
+      }
+    },
+    "node_modules/@firebase/performance-compat": {
+      "version": "0.2.8",
+      "resolved": "https://registry.npmjs.org/@firebase/performance-compat/-/performance-compat-0.2.8.tgz",
+      "integrity": "sha512-o7TFClRVJd3VIBoY7KZQqtCeW0PC6v9uBzM6Lfw3Nc9D7hM6OonqecYvh7NwJ6R14k+xM27frLS4BcCvFHKw2A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.6.8",
+        "@firebase/logger": "0.4.2",
+        "@firebase/performance": "0.6.8",
+        "@firebase/performance-types": "0.2.2",
+        "@firebase/util": "1.9.7",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "@firebase/app-compat": "0.x"
+      }
+    },
+    "node_modules/@firebase/performance-types": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/@firebase/performance-types/-/performance-types-0.2.2.tgz",
+      "integrity": "sha512-gVq0/lAClVH5STrIdKnHnCo2UcPLjJlDUoEB/tB4KM+hAeHUxWKnpT0nemUPvxZ5nbdY/pybeyMe8Cs29gEcHA==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@firebase/remote-config": {
+      "version": "0.4.8",
+      "resolved": "https://registry.npmjs.org/@firebase/remote-config/-/remote-config-0.4.8.tgz",
+      "integrity": "sha512-AMLqe6wfIRnjc6FkCWOSUjhc1fSTEf8o+cv1NolFvbiJ/tU+TqN4pI7pT+MIKQzNiq5fxLehkOx+xtAQBxPJKQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.6.8",
+        "@firebase/installations": "0.6.8",
+        "@firebase/logger": "0.4.2",
+        "@firebase/util": "1.9.7",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "@firebase/app": "0.x"
+      }
+    },
+    "node_modules/@firebase/remote-config-compat": {
+      "version": "0.2.8",
+      "resolved": "https://registry.npmjs.org/@firebase/remote-config-compat/-/remote-config-compat-0.2.8.tgz",
+      "integrity": "sha512-UxSFOp6dzFj2AHB8Bq/BYtbq5iFyizKx4Rd6WxAdaKYM8cnPMeK+l2v+Oogtjae+AeyHRI+MfL2acsfVe5cd2A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.6.8",
+        "@firebase/logger": "0.4.2",
+        "@firebase/remote-config": "0.4.8",
+        "@firebase/remote-config-types": "0.3.2",
+        "@firebase/util": "1.9.7",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "@firebase/app-compat": "0.x"
+      }
+    },
+    "node_modules/@firebase/remote-config-types": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/@firebase/remote-config-types/-/remote-config-types-0.3.2.tgz",
+      "integrity": "sha512-0BC4+Ud7y2aPTyhXJTMTFfrGGLqdYXrUB9sJVAB8NiqJswDTc4/2qrE/yfUbnQJhbSi6ZaTTBKyG3n1nplssaA==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@firebase/storage": {
+      "version": "0.13.0",
+      "resolved": "https://registry.npmjs.org/@firebase/storage/-/storage-0.13.0.tgz",
+      "integrity": "sha512-3RQaYpkR4TwPnPR1XlmDUAXiYt5QVQRGRGY1+/yNyS9ohHOCNNgbcs6a+QYvaDInbYTywrdddKYMFFXKKb1pRg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.6.8",
+        "@firebase/util": "1.9.7",
+        "tslib": "^2.1.0",
+        "undici": "5.28.4"
+      },
+      "peerDependencies": {
+        "@firebase/app": "0.x"
+      }
+    },
+    "node_modules/@firebase/storage-compat": {
+      "version": "0.3.10",
+      "resolved": "https://registry.npmjs.org/@firebase/storage-compat/-/storage-compat-0.3.10.tgz",
+      "integrity": "sha512-KcikeV5dK1H1cXi0zEb7gJ3IZ4dKKCjpyucVK8r/Qv5eNAqeQAzPgKKhsSv67wT1N6DTxmqsNEXwMo0dcrKOEg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.6.8",
+        "@firebase/storage": "0.13.0",
+        "@firebase/storage-types": "0.8.2",
+        "@firebase/util": "1.9.7",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "@firebase/app-compat": "0.x"
+      }
+    },
+    "node_modules/@firebase/storage-types": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/@firebase/storage-types/-/storage-types-0.8.2.tgz",
+      "integrity": "sha512-0vWu99rdey0g53lA7IShoA2Lol1jfnPovzLDUBuon65K7uKG9G+L5uO05brD9pMw+l4HRFw23ah3GwTGpEav6g==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "@firebase/app-types": "0.x",
+        "@firebase/util": "1.x"
+      }
+    },
+    "node_modules/@firebase/util": {
+      "version": "1.9.7",
+      "resolved": "https://registry.npmjs.org/@firebase/util/-/util-1.9.7.tgz",
+      "integrity": "sha512-fBVNH/8bRbYjqlbIhZ+lBtdAAS4WqZumx03K06/u7fJSpz1TGjEMm1ImvKD47w+xaFKIP2ori6z8BrbakRfjJA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@firebase/vertexai-preview": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/@firebase/vertexai-preview/-/vertexai-preview-0.0.3.tgz",
+      "integrity": "sha512-KVtUWLp+ScgiwkDKAvNkVucAyhLVQp6C6lhnVEuIg4mWhWcS3oerjAeVhZT4uNofKwWxRsOaB2Yec7DMTXlQPQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/app-check-interop-types": "0.3.2",
+        "@firebase/component": "0.6.8",
+        "@firebase/logger": "0.4.2",
+        "@firebase/util": "1.9.7",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "@firebase/app": "0.x",
+        "@firebase/app-types": "0.x"
+      }
+    },
+    "node_modules/@firebase/webchannel-wrapper": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@firebase/webchannel-wrapper/-/webchannel-wrapper-1.0.1.tgz",
+      "integrity": "sha512-jmEnr/pk0yVkA7mIlHNnxCi+wWzOFUg0WyIotgkKAb2u1J7fAeDBcVNSTjTihbAYNusCLQdW5s9IJ5qwnEufcQ==",
+      "license": "Apache-2.0"
+    },
     "node_modules/@floating-ui/core": {
       "version": "1.6.4",
       "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.6.4.tgz",
@@ -925,6 +1482,37 @@
       "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.4.tgz",
       "integrity": "sha512-dWO2pw8hhi+WrXq1YJy2yCuWoL20PddgGaqTgVe4cOS9Q6qklXCiA1tJEqX6BEwRNSCP84/afac9hd4MS+zEUA==",
       "license": "MIT"
+    },
+    "node_modules/@grpc/grpc-js": {
+      "version": "1.9.15",
+      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.9.15.tgz",
+      "integrity": "sha512-nqE7Hc0AzI+euzUwDAy0aY5hCp10r734gMGRdU+qOPX0XSceI2ULrcXB5U2xSc5VkWwalCj4M7GzCAygZl2KoQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@grpc/proto-loader": "^0.7.8",
+        "@types/node": ">=12.12.47"
+      },
+      "engines": {
+        "node": "^8.13.0 || >=10.10.0"
+      }
+    },
+    "node_modules/@grpc/proto-loader": {
+      "version": "0.7.13",
+      "resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.7.13.tgz",
+      "integrity": "sha512-AiXO/bfe9bmxBjxxtYxFAXGZvMaN5s8kO+jBHAJCON8rJoB5YS/D6X7ZNc6XQkuHNmyl4CYaMI1fJ/Gn27RGGw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "lodash.camelcase": "^4.3.0",
+        "long": "^5.0.0",
+        "protobufjs": "^7.2.5",
+        "yargs": "^17.7.2"
+      },
+      "bin": {
+        "proto-loader-gen-types": "build/bin/proto-loader-gen-types.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
     },
     "node_modules/@humanwhocodes/config-array": {
       "version": "0.11.14",
@@ -1067,6 +1655,70 @@
       "funding": {
         "url": "https://opencollective.com/unts"
       }
+    },
+    "node_modules/@protobufjs/aspromise": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
+      "integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/base64": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
+      "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/codegen": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.4.tgz",
+      "integrity": "sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/eventemitter": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz",
+      "integrity": "sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/fetch": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.0.tgz",
+      "integrity": "sha512-lljVXpqXebpsijW71PZaCYeIcE5on1w5DlQy5WH6GLbFryLUrBD4932W/E2BSpfRJWseIL4v/KPgBFxDOIdKpQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.1",
+        "@protobufjs/inquire": "^1.1.0"
+      }
+    },
+    "node_modules/@protobufjs/float": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
+      "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/inquire": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.0.tgz",
+      "integrity": "sha512-kdSefcPdruJiFMVSbn801t4vFK7KB/5gd2fYvrxhuJYg8ILrmn9SKSX2tZdV6V+ksulWqS7aXjBcRXl3wHoD9Q==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/path": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
+      "integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/pool": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
+      "integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/utf8": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
+      "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/@remix-run/router": {
       "version": "1.18.0",
@@ -1587,6 +2239,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/node": {
+      "version": "22.5.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.5.0.tgz",
+      "integrity": "sha512-DkFrJOe+rfdHTqqMg0bSNlGlQ85hSoh2TPzZyhHsXnMtligRWpxUySiyw8FY14ITt24HVCiQPWxS3KO/QlGmWg==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.19.2"
+      }
+    },
     "node_modules/@types/prop-types": {
       "version": "15.7.12",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.12.tgz",
@@ -1728,7 +2389,6 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -2107,6 +2767,99 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/cliui": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.1",
+        "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/cliui/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/cliui/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/cliui/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "license": "MIT"
+    },
+    "node_modules/cliui/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "license": "MIT"
+    },
+    "node_modules/cliui/node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cliui/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cliui/node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
       }
     },
     "node_modules/clsx": {
@@ -2619,7 +3372,6 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.2.tgz",
       "integrity": "sha512-ErCHMCae19vR8vQGe50xIsVomy19rg6gFu3+r3jkEO46suLMWBksvVyoGgQV+jOfl84ZSOSlmv6Gxa89PmTGmA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -3088,6 +3840,18 @@
         "reusify": "^1.0.4"
       }
     },
+    "node_modules/faye-websocket": {
+      "version": "0.11.4",
+      "resolved": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.11.4.tgz",
+      "integrity": "sha512-CzbClwlXAuiRQAlUyfqPgvPoNKTckTPGfwZV4ZdAhVcP2lh9KUxJg2b5GkE7XbjKQ3YJnQ9z6D9ntLAlB+tP8g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "websocket-driver": ">=0.5.1"
+      },
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
     "node_modules/file-entry-cache": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.1.tgz",
@@ -3129,6 +3893,41 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/firebase": {
+      "version": "10.13.0",
+      "resolved": "https://registry.npmjs.org/firebase/-/firebase-10.13.0.tgz",
+      "integrity": "sha512-a8gm8c9CYO98QuXJn7m5W5Gj7kHV8fme81/mQ9dBs+VMz9uI5HdavnMVPXCILputpZFMFpiKK+u7VVsn5lQg+w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/analytics": "0.10.7",
+        "@firebase/analytics-compat": "0.2.13",
+        "@firebase/app": "0.10.9",
+        "@firebase/app-check": "0.8.7",
+        "@firebase/app-check-compat": "0.3.14",
+        "@firebase/app-compat": "0.2.39",
+        "@firebase/app-types": "0.9.2",
+        "@firebase/auth": "1.7.7",
+        "@firebase/auth-compat": "0.5.12",
+        "@firebase/database": "1.0.7",
+        "@firebase/database-compat": "1.0.7",
+        "@firebase/firestore": "4.7.0",
+        "@firebase/firestore-compat": "0.3.35",
+        "@firebase/functions": "0.11.6",
+        "@firebase/functions-compat": "0.3.12",
+        "@firebase/installations": "0.6.8",
+        "@firebase/installations-compat": "0.2.8",
+        "@firebase/messaging": "0.12.10",
+        "@firebase/messaging-compat": "0.2.10",
+        "@firebase/performance": "0.6.8",
+        "@firebase/performance-compat": "0.2.8",
+        "@firebase/remote-config": "0.4.8",
+        "@firebase/remote-config-compat": "0.2.8",
+        "@firebase/storage": "0.13.0",
+        "@firebase/storage-compat": "0.3.10",
+        "@firebase/util": "1.9.7",
+        "@firebase/vertexai-preview": "0.0.3"
       }
     },
     "node_modules/flat-cache": {
@@ -3232,6 +4031,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "license": "ISC",
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
       }
     },
     "node_modules/get-intrinsic": {
@@ -3469,6 +4277,12 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/http-parser-js": {
+      "version": "0.5.8",
+      "resolved": "https://registry.npmjs.org/http-parser-js/-/http-parser-js-0.5.8.tgz",
+      "integrity": "sha512-SGeBX54F94Wgu5RH3X5jsDtf4eHyRogWX1XGT3b4HuW3tQPM4AaBzoUji/4AAJNXCEOWZ5O0DgZmJw1947gD5Q==",
+      "license": "MIT"
+    },
     "node_modules/human-signals": {
       "version": "4.3.1",
       "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-4.3.1.tgz",
@@ -3494,6 +4308,12 @@
       "funding": {
         "url": "https://github.com/sponsors/typicode"
       }
+    },
+    "node_modules/idb": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/idb/-/idb-7.1.1.tgz",
+      "integrity": "sha512-gchesWBzyvGHRO9W8tzUWFDycow5gwjvFKfyV9FF32Y7F50yZMp7mP+T2mJIWFx49zicqyC4uefHM17o6xKIVQ==",
+      "license": "ISC"
     },
     "node_modules/ignore": {
       "version": "5.3.1",
@@ -4251,6 +5071,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/lodash.camelcase": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
+      "integrity": "sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==",
+      "license": "MIT"
+    },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
@@ -4306,6 +5132,12 @@
       "funding": {
         "url": "https://github.com/chalk/strip-ansi?sponsor=1"
       }
+    },
+    "node_modules/long": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/long/-/long-5.2.3.tgz",
+      "integrity": "sha512-lcHwpNoggQTObv5apGNCTdJrO69eHOZMi4BNC+rTLER8iHAqGrUVeLh/irVIM7zTw2bOXA8T6uNPeujwOLg/2Q==",
+      "license": "Apache-2.0"
     },
     "node_modules/loose-envify": {
       "version": "1.4.0",
@@ -4907,6 +5739,30 @@
         "react-is": "^16.13.1"
       }
     },
+    "node_modules/protobufjs": {
+      "version": "7.4.0",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.4.0.tgz",
+      "integrity": "sha512-mRUWCc3KUU4w1jU8sGxICXH/gNS94DvI1gxqDvBzhj1JpcsimQkYiOJfwsPUykUI5ZaspFbSgmBLER8IrQ3tqw==",
+      "hasInstallScript": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.2",
+        "@protobufjs/base64": "^1.1.2",
+        "@protobufjs/codegen": "^2.0.4",
+        "@protobufjs/eventemitter": "^1.1.0",
+        "@protobufjs/fetch": "^1.1.0",
+        "@protobufjs/float": "^1.0.2",
+        "@protobufjs/inquire": "^1.1.0",
+        "@protobufjs/path": "^1.1.2",
+        "@protobufjs/pool": "^1.1.0",
+        "@protobufjs/utf8": "^1.1.0",
+        "@types/node": ">=13.7.0",
+        "long": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
     "node_modules/punycode": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -5087,6 +5943,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/resolve": {
@@ -5273,6 +6138,26 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/safe-regex-test": {
       "version": "1.0.3",
@@ -5588,7 +6473,6 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-regex": "^5.0.1"
@@ -5770,7 +6654,6 @@
       "version": "2.6.3",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.3.tgz",
       "integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ==",
-      "dev": true,
       "license": "0BSD"
     },
     "node_modules/type-check": {
@@ -5892,6 +6775,24 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/undici": {
+      "version": "5.28.4",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-5.28.4.tgz",
+      "integrity": "sha512-72RFADWFqKmUb2hmmvNODKL3p9hcB6Gt2DOQMis1SEBaV6a4MH8soBvzg+95CYhCKPFedut2JY9bMfrDl9D23g==",
+      "license": "MIT",
+      "dependencies": {
+        "@fastify/busboy": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14.0"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.19.8",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
+      "integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==",
+      "license": "MIT"
+    },
     "node_modules/update-browserslist-db": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.1.0.tgz",
@@ -6009,6 +6910,29 @@
       "integrity": "sha512-rpJyN222KWIvHJ/F53XSZv0Zl/accqHR8et1kpaMTD/fLCRxtV8iX8czMzY7sVZupTI3zcUTg8eycS2kNF9l6w==",
       "dependencies": {
         "loose-envify": "^1.0.0"
+      }
+    },
+    "node_modules/websocket-driver": {
+      "version": "0.7.4",
+      "resolved": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.7.4.tgz",
+      "integrity": "sha512-b17KeDIQVjvb0ssuSDF2cYXSg2iztliJ4B9WdsuB6J952qCPKmnVq4DyW5motImXHDC1cBT/1UezrJVsKw5zjg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "http-parser-js": ">=0.5.1",
+        "safe-buffer": ">=5.1.0",
+        "websocket-extensions": ">=0.1.1"
+      },
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/websocket-extensions": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/websocket-extensions/-/websocket-extensions-0.1.4.tgz",
+      "integrity": "sha512-OqedPIGOfsDlo31UNwYbCFMSaO9m9G/0faIHj5/dZFDMFqPTcx6UwqyOy3COEaEOg/9VsGIpdqn62W5KhoKSpg==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.8.0"
       }
     },
     "node_modules/which": {
@@ -6187,6 +7111,15 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/yallist": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
@@ -6202,6 +7135,62 @@
       "license": "ISC",
       "engines": {
         "node": ">= 14"
+      }
+    },
+    "node_modules/yargs": {
+      "version": "17.7.2",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
+      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^8.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.3",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^21.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yargs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "license": "MIT"
+    },
+    "node_modules/yargs/node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/yargs/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/yocto-queue": {

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "postinstall": "husky install"
   },
   "dependencies": {
+    "firebase": "^10.13.0",
     "jotai": "^2.9.0",
     "react": "^18.3.1",
     "react-calendar": "^5.0.0",

--- a/src/apis/loadUserData.js
+++ b/src/apis/loadUserData.js
@@ -1,0 +1,15 @@
+import { doc, getDoc } from "firebase/firestore";
+
+// 저장된 데이터 불러오기
+const loadUserData = async (userName) => {
+  const docRef = doc(db, "users", userName);
+  const docSnap = await getDoc(docRef);
+
+  if (docSnap.exists()) {
+    // console.log("Document data:", docSnap.data());
+    return docSnap.data();
+  } else {
+    // console.log("No such document!");
+    return null;
+  }
+};

--- a/src/apis/saveUserData.js
+++ b/src/apis/saveUserData.js
@@ -1,0 +1,25 @@
+import { doc, setDoc } from "firebase/firestore";
+import { useAtomValue } from "jotai";
+import { userNameAtom, themeSiteAtom, minuteCountAtom } from "../../store/atom";
+import { db } from "../../firebase-config";
+
+// 데이터 저장
+const saveUserData = async () => {
+  const userName = useAtomValue(userNameAtom);
+  const themeSite = useAtomValue(themeSiteAtom);
+  const timeSpent = useAtomValue(minuteCountAtom);
+
+  if (userName && themeSite) {
+    try {
+      await setDoc(doc(db, "users", userName), {
+        themeSite: themeSite,
+        timeSpent: timeSpent
+      });
+      // console.log("데이터가 저장되었습니다.");
+    } catch (e) {
+      console.error("데이터 저장 실패: ", e);
+    }
+  }
+};
+
+export default saveUserData;

--- a/src/pages/challengeMode/components/PosterSection.jsx
+++ b/src/pages/challengeMode/components/PosterSection.jsx
@@ -1,0 +1,110 @@
+import React from "react";
+import styled from "styled-components";
+import Poster from "../../../components/poster/Poster";
+import { useAtom } from "jotai";
+import { postersAtom, levelAtom } from "../../../store/atom";
+import { formatDateRange } from "../../../util/date";
+
+// 전체 요소를 담는 컨테이너
+const PosterContainer = styled.div`
+  display: flex;
+  justify-content: flex-start;
+  align-items: flex-start;
+  flex-direction: row;
+  flex-shrink: 0;
+`;
+
+// 포스터 이미지만 담는 섹션
+const LeftSection = styled.div`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  margin-right: 20px;
+`;
+
+// 타이틀과 공연 정보를 담는 섹션
+const RightSection = styled.div`
+  display: flex;
+  flex-direction: column;
+  justify-content: flex-start;
+  align-items: flex-start;
+`;
+
+// 공연 제목
+const PosterTitle = styled.h2`
+  font-family: "pretendardB";
+  font-size: 24px;
+  margin-bottom: 20px;
+  align-self: flex-start;
+`;
+
+// 테이블 스타일
+const InfoTable = styled.table`
+  width: 100%;
+  border-collapse: collapse;
+  font-family: "pretendardR";
+  font-size: 16px;
+  padding: 4px 8px;
+  color: var(--text-color);
+`;
+
+const InfoRow = styled.tr``;
+
+const InfoLabel = styled.td`
+  padding: 8px;
+  font-weight: bold;
+`;
+
+const InfoValue = styled.td`
+  padding: 8px;
+`;
+
+const PosterSection = ({ id }) => {
+  const [posters] = useAtom(postersAtom);
+  const [level] = useAtom(levelAtom);
+  const poster = posters[id];
+
+  return (
+    <PosterContainer>
+      <LeftSection>
+        <Poster id={id} />
+      </LeftSection>
+      <RightSection>
+        <PosterTitle>{poster.title_ko}</PosterTitle>
+        <InfoTable>
+          <tbody>
+            <InfoRow>
+              <InfoLabel>장소</InfoLabel>
+              <InfoValue>{poster.venue}</InfoValue>
+            </InfoRow>
+            <InfoRow>
+              <InfoLabel>공연기간</InfoLabel>
+              <InfoValue>{formatDateRange(poster.date)}</InfoValue>
+            </InfoRow>
+            <InfoRow>
+              <InfoLabel>관람연령</InfoLabel>
+              <InfoValue>{poster.age}</InfoValue>
+            </InfoRow>
+            <InfoRow>
+              <InfoLabel>가격</InfoLabel>
+              <InfoValue>
+                <table>
+                  <tbody>
+                    {Object.entries(poster.price).map(([seatType, price]) => (
+                      <InfoRow key={seatType}>
+                        <InfoLabel>{seatType}</InfoLabel>
+                        <InfoValue>{price}</InfoValue>
+                      </InfoRow>
+                    ))}
+                  </tbody>
+                </table>
+              </InfoValue>
+            </InfoRow>
+          </tbody>
+        </InfoTable>
+      </RightSection>
+    </PosterContainer>
+  );
+};
+
+export default PosterSection;

--- a/src/pages/challengeMode/interpark/step1/PosterInterpark.jsx
+++ b/src/pages/challengeMode/interpark/step1/PosterInterpark.jsx
@@ -8,10 +8,9 @@ import { formatDateRange } from "../../../../util/date";
 // 전체 요소를 담는 컨테이너
 const PosterContainer = styled.div`
   display: flex;
-  justify-content: flex-start; /* 좌측 정렬 */
-  align-items: flex-start; /* 상단 정렬 */
+  justify-content: flex-start;
+  align-items: flex-start;
   flex-direction: row;
-
   flex-shrink: 0;
 `;
 

--- a/src/pages/challengeMode/interpark/step1/SelectRoundInterpark.jsx
+++ b/src/pages/challengeMode/interpark/step1/SelectRoundInterpark.jsx
@@ -7,8 +7,6 @@ import { useAtom } from "jotai";
 import {
   themeSiteAtom,
   selectedPosterAtom,
-  levelAtom,
-  progressAtom,
   postersAtom
 } from "../../../../store/atom";
 import { useNavigate } from "react-router-dom";
@@ -16,8 +14,8 @@ import formatTime from "../../../../util/time";
 
 const Container = styled.div`
   display: flex;
-  justify-content: space-between; /* 좌우로 공간 배분 */
-  align-items: flex-start; /* 상단 정렬 */
+  justify-content: space-between;
+  align-items: flex-start;
   padding: 20px 50px;
   width: 100%;
 `;
@@ -25,16 +23,16 @@ const Container = styled.div`
 const LeftSection = styled.div`
   display: flex;
   flex-direction: column;
-  justify-content: flex-start; /* 콘텐츠 상단 정렬 */
+  justify-content: flex-start;
   align-items: center;
 `;
 
 const RightSection = styled.div`
   display: flex;
   flex-direction: column;
-  justify-content: flex-start; /* 콘텐츠 상단 정렬 */
+  justify-content: flex-start;
   align-items: flex-start;
-  padding-left: 20px; /* 좌측 여백 추가 */
+  padding-left: 20px;
 `;
 
 const BoxWrapper = styled.div`
@@ -47,14 +45,12 @@ const BoxWrapper = styled.div`
 const RoundWrapper = styled.div`
   display: flex;
   flex-direction: column;
-  gap: 10px; /* 버튼 사이의 간격 추가 */
+  gap: 10px;
   width: 100%;
   padding-left: 20px;
 `;
 
 const SelectRoundInterpark = () => {
-  const [, setLevel] = useAtom(levelAtom);
-  const [, setProgress] = useAtom(progressAtom);
   const [selectedPoster] = useAtom(selectedPosterAtom);
   const [posters] = useAtom(postersAtom);
   const [posterId, setPosterId] = useState(0);
@@ -66,11 +62,9 @@ const SelectRoundInterpark = () => {
   const [, setThemeSite] = useAtom(themeSiteAtom);
 
   useEffect(() => {
-    setProgress(1);
     setThemeSite("interpark");
-    setLevel("high");
     setPosterId(0);
-  }, [setLevel, setProgress, selectedPoster, setThemeSite]);
+  }, [setThemeSite]);
 
   const poster = posters[posterId];
   const posterDates = poster ? poster.date : [];

--- a/src/pages/challengeMode/melonticket/step1/SelectRoundMelonticket.jsx
+++ b/src/pages/challengeMode/melonticket/step1/SelectRoundMelonticket.jsx
@@ -1,0 +1,161 @@
+import React, { useEffect, useState } from "react";
+import PosterSection from "../../components/PosterSection";
+import SelectCalender from "../../../../components/calender/SelectCalender";
+import Button from "../../../../components/button/Button";
+import styled from "styled-components";
+import { useAtomValue, useSetAtom } from "jotai";
+import {
+  themeSiteAtom,
+  selectedPosterAtom,
+  postersAtom
+} from "../../../../store/atom";
+import { useNavigate } from "react-router-dom";
+import formatTime from "../../../../util/time";
+
+const Container = styled.div`
+  display: flex;
+  flex-direction: column;
+  justify-content: flex-start;
+  align-items: center;
+  padding: 0 20vh;
+  box-sizing: border-box;
+`;
+
+const UpperSection = styled.div`
+  width: 100%;
+  display: flex;
+  justify-content: flex-start;
+  align-items: center;
+  margin-bottom: 30px;
+`;
+
+const LowerSection = styled.div`
+  width: 100%;
+  display: flex;
+  flex-direction: row;
+  gap: 30px;
+  justify-content: flex-start;
+  align-items: flex-start;
+`;
+
+const BoxWrapper = styled.div`
+  width: auto;
+  border: 1px solid var(--fill-color);
+  padding: 20px;
+  border-radius: 8px;
+  gap: 10px;
+  display: flex;
+  flex-direction: row;
+`;
+
+const TitleText = styled.p`
+  font-size: 18px;
+  white-space: nowrap; // 글자 크기 고정
+  margin: 0;
+`;
+
+const ButtonSection = styled.div`
+  width: 100%;
+  display: flex;
+  padding-top: 20px;
+  justify-content: flex-end;
+`;
+
+const SelectRoundMelonticket = () => {
+  const selectedPoster = useAtomValue(selectedPosterAtom);
+  const posters = useAtomValue(postersAtom);
+  const [posterId, setPosterId] = useState(0);
+  const [dateSelected, setDateSelected] = useState(false);
+  const [roundSelected, setRoundSelected] = useState(false);
+  const [timesButtons, setTimesButtons] = useState([]);
+  const [correctRound, setCorrectRound] = useState(null);
+  const navigate = useNavigate();
+  const setThemeSite = useSetAtom(themeSiteAtom);
+
+  useEffect(() => {
+    setThemeSite("melonticket");
+    setPosterId(1);
+  }, [setThemeSite]);
+
+  const poster = posters[posterId];
+  const posterDates = poster?.date || [];
+  const posterTimes = poster?.time || {};
+
+  const handleDateSelect = (formattedDate) => {
+    const correctDate = posterDates[0];
+    if (formattedDate === correctDate) {
+      setDateSelected(true);
+      const timesArray = formatTime(posterTimes, formattedDate);
+      setTimesButtons(timesArray);
+      if (timesArray.length > 0) {
+        setCorrectRound(timesArray[0]);
+      }
+    } else {
+      alert("날짜를 다시 선택해주세요.");
+    }
+  };
+
+  const handleRoundClick = (time) => {
+    if (!dateSelected) {
+      alert("먼저 올바른 날짜를 선택해주세요.");
+      return;
+    }
+    if (time === correctRound) {
+      alert(`${time}으로 공연을 예매합니다.`);
+      setRoundSelected(true);
+    } else {
+      alert("회차를 다시 선택해주세요.");
+    }
+  };
+
+  const handleReserveClick = () => {
+    if (!roundSelected) {
+      alert("먼저 회차를 선택해주세요.");
+      return;
+    }
+    navigate("/challenge/melonticket/step2");
+  };
+
+  return (
+    <Container>
+      <UpperSection>
+        <PosterSection id={posterId} />
+      </UpperSection>
+      <LowerSection>
+        <BoxWrapper>
+          <TitleText>날짜 선택</TitleText>
+          <SelectCalender
+            onDateSelect={handleDateSelect}
+            initialDate={
+              posterDates.length > 0 ? new Date(posterDates[0]) : new Date()
+            }
+          />
+        </BoxWrapper>
+        <BoxWrapper>
+          <TitleText>회차 선택</TitleText>
+          {timesButtons.length > 0 ? (
+            timesButtons.map((time, index) => (
+              <Button
+                key={index}
+                text={`${index + 1}회 - ${time}`}
+                type="outline"
+                onClick={() => handleRoundClick(time)}
+              />
+            ))
+          ) : (
+            <Button
+              text="날짜 선택 후 확인"
+              type="outline"
+              onClick={() => alert("날짜를 먼저 선택해주세요.")}
+            />
+          )}
+        </BoxWrapper>
+      </LowerSection>
+      <ButtonSection>
+        <Button text="인증 후 예매하기" onClick={handleReserveClick} />
+      </ButtonSection>
+    </Container>
+  );
+};
+
+export default SelectRoundMelonticket;

--- a/src/pages/challengeMode/outro/Outro.jsx
+++ b/src/pages/challengeMode/outro/Outro.jsx
@@ -1,0 +1,80 @@
+import React, { useEffect } from "react";
+import styled from "styled-components";
+import Button from "../../../components/button/Button";
+import { useAtom, useSetAtom } from "jotai";
+import { progressAtom, themeSiteAtom } from "../../../store/atom";
+import { useNavigate } from "react-router-dom";
+
+const Step5Container = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  height: 50vh;
+  text-align: center;
+`;
+
+const SuccessMessage = styled.h1`
+  color: var(--key-color);
+  font-family: "pretendardB";
+  font-size: 70px;
+  font-style: normal;
+  font-weight: 700;
+  line-height: normal;
+  letter-spacing: -3.5px;
+  margin-bottom: 20px;
+`;
+
+const PracticeMessage = styled.p`
+  color: var(--text-color);
+  font-family: "pretendardM";
+  font-size: 40px;
+  font-weight: 600;
+  letter-spacing: -2px;
+  margin-bottom: 40px;
+`;
+
+const ButtonWrapper = styled.div`
+  display: flex;
+  flex-direction: row;
+  gap: 20px;
+`;
+
+const Outro = () => {
+  const [, setProgress] = useAtom(progressAtom);
+  const navigate = useNavigate();
+  const setThemeSite = useSetAtom(themeSiteAtom);
+
+  useEffect(() => {
+    setProgress(5);
+    setThemeSite("practice");
+  }, [setProgress]);
+
+  // 다시 도전하기(사이트 선택)
+  const handlePracticeModeClick = () => {
+    navigate("/select-site");
+  };
+
+  // 기록 보기
+  const handleChallengeModeClick = () => {
+    navigate("/record");
+  };
+
+  return (
+    <Step5Container>
+      <SuccessMessage>예매 성공!</SuccessMessage>
+      {/* 클리어 시간 추가 필요*/}
+      <PracticeMessage>다시 도전하시겠습니까?</PracticeMessage>
+      <ButtonWrapper>
+        <Button text="다시 도전하기" onClick={handlePracticeModeClick} />
+        <Button
+          text="기록 보러가기"
+          type="outline"
+          onClick={handleChallengeModeClick}
+        />
+      </ButtonWrapper>
+    </Step5Container>
+  );
+};
+
+export default Outro;

--- a/src/pages/challengeMode/outro/Record.jsx
+++ b/src/pages/challengeMode/outro/Record.jsx
@@ -1,0 +1,73 @@
+import React, { useEffect, useState } from "react";
+import styled from "styled-components";
+import { collection, getDocs } from "firebase/firestore";
+import { db } from "../../../../firebase-config";
+
+const RecordContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  padding: 20px;
+`;
+
+const RecordTitle = styled.h2`
+  font-family: "pretendardB";
+  font-size: 36px;
+  color: var(--key-color);
+  padding: 20px;
+`;
+
+const RecordList = styled.ul`
+  list-style: none;
+`;
+
+const RecordItem = styled.li`
+  display: flex;
+  padding: 10px;
+  margin-bottom: 10px;
+  font-family: "pretendardR";
+  font-size: 24px;
+  color: var(--text-color);
+`;
+
+const Record = () => {
+  const [records, setRecords] = useState([]);
+
+  // 데이터베이스로부터 데이터 읽어오기
+  useEffect(() => {
+    const fetchRecords = async () => {
+      try {
+        const querySnapshot = await getDocs(collection(db, "users"));
+        const recordsArray = querySnapshot.docs.map((doc) => ({
+          userName: doc.id,
+          ...doc.data()
+        }));
+        // 남은 시간이 많은 순으로 정렬
+        recordsArray.sort((a, b) => b.timeSpent - a.timeSpent);
+        setRecords(recordsArray);
+      } catch (error) {
+        console.error("Error fetching datas: ", error);
+      }
+    };
+
+    fetchRecords();
+  }, []);
+
+  return (
+    <RecordContainer>
+      <RecordTitle>클리어 기록 보기</RecordTitle>
+      <RecordList>
+        {records.map((record, index) => (
+          <RecordItem key={index}>
+            {index + 1}. {record.userName} -{" "}
+            {String(Math.floor(record.timeSpent / 60)).padStart(2, "0")}:
+            {String(record.timeSpent % 60).padStart(2, "0")}
+          </RecordItem>
+        ))}
+      </RecordList>
+    </RecordContainer>
+  );
+};
+
+export default Record;

--- a/src/pages/challengeMode/selectSite/SelectSite.jsx
+++ b/src/pages/challengeMode/selectSite/SelectSite.jsx
@@ -42,6 +42,7 @@ const SelectSite = () => {
 
   const handleClick = (path, themeSite) => {
     setThemeSite(themeSite); // 해당 사이트의 테마로 변경
+    setLevel("high"); // 고급 난이도로 변경
     navigate(path);
   };
 

--- a/src/pages/challengeMode/ticketlink/step1/SelectRoundTicketlink.jsx
+++ b/src/pages/challengeMode/ticketlink/step1/SelectRoundTicketlink.jsx
@@ -1,0 +1,161 @@
+import React, { useEffect, useState } from "react";
+import PosterSection from "../../components/PosterSection";
+import SelectCalender from "../../../../components/calender/SelectCalender";
+import Button from "../../../../components/button/Button";
+import styled from "styled-components";
+import { useAtomValue, useSetAtom } from "jotai";
+import {
+  themeSiteAtom,
+  selectedPosterAtom,
+  postersAtom
+} from "../../../../store/atom";
+import { useNavigate } from "react-router-dom";
+import formatTime from "../../../../util/time";
+
+const Container = styled.div`
+  display: flex;
+  flex-direction: column;
+  justify-content: flex-start;
+  align-items: center;
+  padding: 0 20vh;
+  box-sizing: border-box;
+`;
+
+const UpperSection = styled.div`
+  width: 100%;
+  display: flex;
+  justify-content: flex-start;
+  align-items: center;
+  margin-bottom: 30px;
+`;
+
+const LowerSection = styled.div`
+  width: 100%;
+  display: flex;
+  flex-direction: row;
+  gap: 30px;
+  justify-content: flex-start;
+  align-items: flex-start;
+`;
+
+const BoxWrapper = styled.div`
+  width: auto;
+  border: 1px solid var(--fill-color);
+  padding: 20px;
+  border-radius: 8px;
+  gap: 10px;
+  display: flex;
+  flex-direction: row;
+`;
+
+const TitleText = styled.p`
+  font-size: 18px;
+  white-space: nowrap; // 글자 크기 고정
+  margin: 0;
+`;
+
+const ButtonSection = styled.div`
+  width: 100%;
+  display: flex;
+  padding-top: 20px;
+  justify-content: flex-end;
+`;
+
+const SelectRoundTicketlink = () => {
+  const selectedPoster = useAtomValue(selectedPosterAtom);
+  const posters = useAtomValue(postersAtom);
+  const [posterId, setPosterId] = useState(0);
+  const [dateSelected, setDateSelected] = useState(false);
+  const [roundSelected, setRoundSelected] = useState(false);
+  const [timesButtons, setTimesButtons] = useState([]);
+  const [correctRound, setCorrectRound] = useState(null);
+  const navigate = useNavigate();
+  const setThemeSite = useSetAtom(themeSiteAtom);
+
+  useEffect(() => {
+    setThemeSite("ticketlink");
+    setPosterId(2);
+  }, [setThemeSite]);
+
+  const poster = posters[posterId];
+  const posterDates = poster?.date || [];
+  const posterTimes = poster?.time || {};
+
+  const handleDateSelect = (formattedDate) => {
+    const correctDate = posterDates[0];
+    if (formattedDate === correctDate) {
+      setDateSelected(true);
+      const timesArray = formatTime(posterTimes, formattedDate);
+      setTimesButtons(timesArray);
+      if (timesArray.length > 0) {
+        setCorrectRound(timesArray[0]);
+      }
+    } else {
+      alert("날짜를 다시 선택해주세요.");
+    }
+  };
+
+  const handleRoundClick = (time) => {
+    if (!dateSelected) {
+      alert("먼저 올바른 날짜를 선택해주세요.");
+      return;
+    }
+    if (time === correctRound) {
+      alert(`${time}으로 공연을 예매합니다.`);
+      setRoundSelected(true);
+    } else {
+      alert("회차를 다시 선택해주세요.");
+    }
+  };
+
+  const handleReserveClick = () => {
+    if (!roundSelected) {
+      alert("먼저 회차를 선택해주세요.");
+      return;
+    }
+    navigate("/challenge/ticketlink/step2");
+  };
+
+  return (
+    <Container>
+      <UpperSection>
+        <PosterSection id={posterId} />
+      </UpperSection>
+      <LowerSection>
+        <BoxWrapper>
+          <TitleText>날짜 선택</TitleText>
+          <SelectCalender
+            onDateSelect={handleDateSelect}
+            initialDate={
+              posterDates.length > 0 ? new Date(posterDates[0]) : new Date()
+            }
+          />
+        </BoxWrapper>
+        <BoxWrapper>
+          <TitleText>회차 선택</TitleText>
+          {timesButtons.length > 0 ? (
+            timesButtons.map((time, index) => (
+              <Button
+                key={index}
+                text={`${index + 1}회 - ${time}`}
+                type="outline"
+                onClick={() => handleRoundClick(time)}
+              />
+            ))
+          ) : (
+            <Button
+              text="날짜 선택 후 확인"
+              type="outline"
+              onClick={() => alert("날짜를 먼저 선택해주세요.")}
+            />
+          )}
+        </BoxWrapper>
+      </LowerSection>
+      <ButtonSection>
+        <Button text="인증 후 예매하기" onClick={handleReserveClick} />
+      </ButtonSection>
+    </Container>
+  );
+};
+
+export default SelectRoundTicketlink;

--- a/src/pages/challengeMode/yes24/step1/SelectRoundYes24.jsx
+++ b/src/pages/challengeMode/yes24/step1/SelectRoundYes24.jsx
@@ -1,0 +1,161 @@
+import React, { useEffect, useState } from "react";
+import PosterSection from "../../components/PosterSection";
+import SelectCalender from "../../../../components/calender/SelectCalender";
+import Button from "../../../../components/button/Button";
+import styled from "styled-components";
+import { useAtomValue, useSetAtom } from "jotai";
+import {
+  themeSiteAtom,
+  selectedPosterAtom,
+  postersAtom
+} from "../../../../store/atom";
+import { useNavigate } from "react-router-dom";
+import formatTime from "../../../../util/time";
+
+const Container = styled.div`
+  display: flex;
+  flex-direction: column;
+  justify-content: flex-start;
+  align-items: center;
+  padding: 0 20vh;
+  box-sizing: border-box;
+`;
+
+const UpperSection = styled.div`
+  width: 100%;
+  display: flex;
+  justify-content: flex-start;
+  align-items: center;
+  margin-bottom: 30px;
+`;
+
+const LowerSection = styled.div`
+  width: 100%;
+  display: flex;
+  flex-direction: row;
+  gap: 30px;
+  justify-content: flex-start;
+  align-items: flex-start;
+`;
+
+const BoxWrapper = styled.div`
+  width: auto;
+  border: 1px solid var(--fill-color);
+  padding: 20px;
+  border-radius: 8px;
+  gap: 10px;
+  display: flex;
+  flex-direction: row;
+`;
+
+const TitleText = styled.p`
+  font-size: 18px;
+  white-space: nowrap; // 글자 크기 고정
+  margin: 0;
+`;
+
+const ButtonSection = styled.div`
+  width: 100%;
+  display: flex;
+  padding-top: 20px;
+  justify-content: flex-end;
+`;
+
+const SelectRoundYes24 = () => {
+  const selectedPoster = useAtomValue(selectedPosterAtom);
+  const posters = useAtomValue(postersAtom);
+  const [posterId, setPosterId] = useState(0);
+  const [dateSelected, setDateSelected] = useState(false);
+  const [roundSelected, setRoundSelected] = useState(false);
+  const [timesButtons, setTimesButtons] = useState([]);
+  const [correctRound, setCorrectRound] = useState(null);
+  const navigate = useNavigate();
+  const setThemeSite = useSetAtom(themeSiteAtom);
+
+  useEffect(() => {
+    setThemeSite("yes24");
+    setPosterId(3);
+  }, [setThemeSite]);
+
+  const poster = posters[posterId];
+  const posterDates = poster?.date || [];
+  const posterTimes = poster?.time || {};
+
+  const handleDateSelect = (formattedDate) => {
+    const correctDate = posterDates[0];
+    if (formattedDate === correctDate) {
+      setDateSelected(true);
+      const timesArray = formatTime(posterTimes, formattedDate);
+      setTimesButtons(timesArray);
+      if (timesArray.length > 0) {
+        setCorrectRound(timesArray[0]);
+      }
+    } else {
+      alert("날짜를 다시 선택해주세요.");
+    }
+  };
+
+  const handleRoundClick = (time) => {
+    if (!dateSelected) {
+      alert("먼저 올바른 날짜를 선택해주세요.");
+      return;
+    }
+    if (time === correctRound) {
+      alert(`${time}으로 공연을 예매합니다.`);
+      setRoundSelected(true);
+    } else {
+      alert("회차를 다시 선택해주세요.");
+    }
+  };
+
+  const handleReserveClick = () => {
+    if (!roundSelected) {
+      alert("먼저 회차를 선택해주세요.");
+      return;
+    }
+    navigate("/challenge/yes24/step2");
+  };
+
+  return (
+    <Container>
+      <UpperSection>
+        <PosterSection id={posterId} />
+      </UpperSection>
+      <LowerSection>
+        <BoxWrapper>
+          <TitleText>날짜 선택</TitleText>
+          <SelectCalender
+            onDateSelect={handleDateSelect}
+            initialDate={
+              posterDates.length > 0 ? new Date(posterDates[0]) : new Date()
+            }
+          />
+        </BoxWrapper>
+        <BoxWrapper>
+          <TitleText>회차 선택</TitleText>
+          {timesButtons.length > 0 ? (
+            timesButtons.map((time, index) => (
+              <Button
+                key={index}
+                text={`${index + 1}회 - ${time}`}
+                type="outline"
+                onClick={() => handleRoundClick(time)}
+              />
+            ))
+          ) : (
+            <Button
+              text="날짜 선택 후 확인"
+              type="outline"
+              onClick={() => alert("날짜를 먼저 선택해주세요.")}
+            />
+          )}
+        </BoxWrapper>
+      </LowerSection>
+      <ButtonSection>
+        <Button text="인증 후 예매하기" onClick={handleReserveClick} />
+      </ButtonSection>
+    </Container>
+  );
+};
+
+export default SelectRoundYes24;

--- a/src/routes.jsx
+++ b/src/routes.jsx
@@ -14,6 +14,9 @@ import ChallangeIntro from "./pages/challengeMode/intro/ChallangeIntro";
 import SelectPerformance from "./pages/practiceMode/step1/SelectPerformance";
 import SelectRound from "./pages/practiceMode/step1/SelectRound";
 import SelectRoundInterpark from "./pages/challengeMode/interpark/step1/SelectRoundInterpark";
+import SelectRoundMelonticket from "./pages/challengeMode/melonticket/step1/SelectRoundMelonticket";
+import SelectRoundTicketlink from "./pages/challengeMode/ticketlink/step1/SelectRoundTicketlink";
+import SelectRoundYes24 from "./pages/challengeMode/yes24/step1/SelectRoundYes24";
 // step 2
 import SelectSeat from "./pages/practiceMode/step2/SelectSeat";
 import SelectSeatInterpark from "./pages/challengeMode/interpark/step2/SelectSeatInterpark";
@@ -133,6 +136,11 @@ const router = createBrowserRouter([
                 path: "step0",
                 element: <PrivateRoute element={<ChallangeIntro />} />,
                 lable: "인트로"
+              },
+              {
+                path: "step1",
+                element: <PrivateRoute element={<SelectRoundMelonticket />} />,
+                label: "날짜 및 회차 선택"
               }
             ]
           },
@@ -144,6 +152,11 @@ const router = createBrowserRouter([
                 path: "step0",
                 element: <PrivateRoute element={<ChallangeIntro />} />,
                 lable: "인트로"
+              },
+              {
+                path: "step1",
+                element: <PrivateRoute element={<SelectRoundTicketlink />} />,
+                label: "날짜 및 회차 선택"
               }
             ]
           },
@@ -155,6 +168,11 @@ const router = createBrowserRouter([
                 path: "step0",
                 element: <PrivateRoute element={<ChallangeIntro />} />,
                 lable: "인트로"
+              },
+              {
+                path: "step1",
+                element: <PrivateRoute element={<SelectRoundYes24 />} />,
+                label: "날짜 및 회차 선택"
               }
             ]
           }

--- a/src/routes.jsx
+++ b/src/routes.jsx
@@ -28,6 +28,9 @@ import SelectPayMethod from "./pages/practiceMode/step4/SelectPayMethod";
 import CardPay from "./pages/practiceMode/step4/CardPay";
 // step 5
 import Step5 from "./pages/practiceMode/step5/Step5";
+import Outro from "./pages/challengeMode/outro/Outro";
+// 기록 보기
+import Record from "./pages/challengeMode/outro/Record";
 
 const router = createBrowserRouter([
   {
@@ -38,6 +41,7 @@ const router = createBrowserRouter([
       { path: "select-mode", element: <SelectMode />, label: "모드 선택" },
       { path: "select-level", element: <SelectLevel />, label: "난이도 선택" },
       { path: "select-site", element: <SelectSite />, label: "사이트 선택" },
+      { path: "record", element: <Record />, label: "기록 보기" },
       {
         path: "progress",
         element: <ProgressContents />,
@@ -123,7 +127,7 @@ const router = createBrowserRouter([
               },
               {
                 path: "step5",
-                element: <PrivateRoute element={<Step5 />} />,
+                element: <PrivateRoute element={<Outro />} />,
                 label: "예매 성공"
               }
             ]
@@ -141,6 +145,11 @@ const router = createBrowserRouter([
                 path: "step1",
                 element: <PrivateRoute element={<SelectRoundMelonticket />} />,
                 label: "날짜 및 회차 선택"
+              },
+              {
+                path: "step5",
+                element: <PrivateRoute element={<Outro />} />,
+                label: "예매 성공"
               }
             ]
           },
@@ -157,6 +166,11 @@ const router = createBrowserRouter([
                 path: "step1",
                 element: <PrivateRoute element={<SelectRoundTicketlink />} />,
                 label: "날짜 및 회차 선택"
+              },
+              {
+                path: "step5",
+                element: <PrivateRoute element={<Outro />} />,
+                label: "예매 성공"
               }
             ]
           },
@@ -173,6 +187,11 @@ const router = createBrowserRouter([
                 path: "step1",
                 element: <PrivateRoute element={<SelectRoundYes24 />} />,
                 label: "날짜 및 회차 선택"
+              },
+              {
+                path: "step5",
+                element: <PrivateRoute element={<Outro />} />,
+                label: "예매 성공"
               }
             ]
           }


### PR DESCRIPTION
# 📝작업 내용
### ✅ 실전모드의 Step5 페이지 임시 구현
- Outro.jsx라는 이름으로 만들어 연습모드 Step5 페이지와 구분되도록 함.
- 아웃트로로 지은 이유는 처음 시작이 Intro여서.. 혹시 더 좋은 아이디어가 있다면 추천부탁해!
- 클리어 타임을 알려주는 부분은 아직 추가하지 못함. 추후 피그마처럼 수정할 예정
![2024-08-26 00 44 43](https://github.com/user-attachments/assets/3835def6-ba29-4d4e-8a98-4d2893b6725b)

### ✅ Firebase 초기 설정
- npm 패키지 설치 및 firebase-config.js에서 api key로 초기화 완료
- 노션에 있는 .env파일을 반드시 생성해야 제대로 동작할 것임. 경로는 root로(아래 사진 참조)
  - api key들이 노출되지 않게 하기 위함이며, gitignore에도 환경변수파일을 무시하도록 설정함 
![image](https://github.com/user-attachments/assets/03d857b8-c0a7-4b11-988c-544e3ac10e38)
- Cloud Firestore DataBase 페이지에서 컬렉션 시작을 누르고 데이터베이스를 만들어둠. 두 명 모두 초대 완료!
- 데이터베이스 자체 이름은 users, 필드는 themeSite, userName, timeSpent로 설정하여 유저 이름, 테마 정보, 예매 성공 시 남은 시간을 저장할 수 있도록 만들어 둠! 

### ✅ 기록 읽기 및 쓰기 함수 모듈화
- `apis/` 폴더를 만들고 데이터를 서버로 보내고 받는 함수들을 모듈화해놓음.
- `loadUserData.js`: 서버에서 데이터 읽어오기(get), 동작 제대로 되는 중!
- `saveUserData.js`: 서버로 데이터 보내기(post), 아직 테스트 못함..


### ✅ `Record.jsx` 임시 구현
- 기록 보기 페이지를 임시로 만듦
- loadUserData가 제대로 동작하는지 확인하기 위해, 파이어베이스 콘솔에서 임의의 데이터를 미리 넣어두고 제대로 읽어오는 것을 확인했음! 일단 서버 테스트를 위해서 임시로 구현해둔거라 세부적인 수정이나 디자인은 추후에 변경할 예정!
![2024-08-26 00 39 37](https://github.com/user-attachments/assets/17b9d4c2-69bb-43ef-a615-9360a7832b1f)
![2024-08-26 00 10 12](https://github.com/user-attachments/assets/bbdce1cd-7afe-4e35-8fc4-6d58784d01ec)


## 💬리뷰 요구사항
일단 파이어베이스 관련 내용은 노션의 문서 페이지에 따로 작성해두었음😃

### 🔎 Firestore Database 구조가 적절한가?
현재는 themeSite를 같이 관리하고 있는데, themeSite별로 4개의 데이터베이스를 따로 만드는 방법도 있음.
하지만 복잡해질 것 같아서 그냥 하나로 통일하고, 프론트 코드 내에서 테마 별로 필터링하는 게 더 공부에 도움이 될 것 같아서 일단 그렇게 진행해보려고 함! 
혹시 필드 구조를 바꾼다거나 다른 좋은 의견이 있다면 논의해도 좋아.

### 🔎 로그인 방식에 대해
로그인이 복잡하게 이뤄지면 오히려 서비스를 이용하기 어려울 것 같음...
따라서 그냥 userName만 입력하면 데이터를 기록할 수 있게 구현하고 싶은데 이에 대해 어떻게 생각하는 지 궁금해!

### 🔎 데이터를 서버로 보낼때 어느 시점에서 보내야할지?
Timer 컴포넌트에서 타이머를 초기화하기 전 데이터를 전송하는 것이 올바른 방법일까? 아니면 컴포넌트가 아니라 Step4에서 Step5로 넘어가기 전 해당 페이지에서 데이터를 전송해야 할까? minuteAtom이 세션 스토리지에서 사라지기 전 서버로 전송해야하는데 고민중이야...!


