### PR TITLE
Feat/Refactor : 인터파크 예매자 정보 / 결제 수단 선택 / 결제창 제작 및 리팩토링

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,6 @@ dist-ssr
 *.sw?
 
 .eslintcache
+
+# Firebase
+.env

--- a/firebase-config.js
+++ b/firebase-config.js
@@ -1,0 +1,20 @@
+import { initializeApp } from "firebase/app";
+import { getAnalytics } from "firebase/analytics";
+import { getFirestore } from "firebase/firestore";
+
+// console.log("환경 변수 적용 테스트:", import.meta.env.VITE_API_KEY);
+
+const firebaseConfig = {
+  apiKey: import.meta.env.VITE_API_KEY,
+  authDomain: import.meta.env.VITE_AUTH_DOMAIN,
+  projectId: import.meta.env.VITE_PROJECT_ID,
+  storageBucket: import.meta.env.VITE_STORAGE_BUCKET,
+  messagingSenderId: import.meta.env.VITE_MESSAGING_SENDER_ID,
+  appId: import.meta.env.VITE_APP_ID,
+  measurementId: import.meta.env.VITE_MEASUREMENT_ID
+};
+
+// 파이어베이스 초기화
+const app = initializeApp(firebaseConfig);
+const analytics = getAnalytics(app);
+export const db = getFirestore(app);

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.0",
       "hasInstallScript": true,
       "dependencies": {
+        "firebase": "^10.13.0",
         "jotai": "^2.9.0",
         "react": "^18.3.1",
         "react-calendar": "^5.0.0",
@@ -901,6 +902,562 @@
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
     },
+    "node_modules/@fastify/busboy": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@fastify/busboy/-/busboy-2.1.1.tgz",
+      "integrity": "sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@firebase/analytics": {
+      "version": "0.10.7",
+      "resolved": "https://registry.npmjs.org/@firebase/analytics/-/analytics-0.10.7.tgz",
+      "integrity": "sha512-GE29uTT6y/Jv2EP0OjpTezeTQZ5FTCTaZXKrrdVGjb/t35AU4u/jiU+hUwUPpuK8fqhhiHkS/AawE3a3ZK/a9Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.6.8",
+        "@firebase/installations": "0.6.8",
+        "@firebase/logger": "0.4.2",
+        "@firebase/util": "1.9.7",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "@firebase/app": "0.x"
+      }
+    },
+    "node_modules/@firebase/analytics-compat": {
+      "version": "0.2.13",
+      "resolved": "https://registry.npmjs.org/@firebase/analytics-compat/-/analytics-compat-0.2.13.tgz",
+      "integrity": "sha512-aZ4wGfNDMsCxhKzDbK2g1aV0JKsdQ9FbeIsjpNJPzhahV0XYj+z36Y4RNLPpG/6hHU4gxnezxs+yn3HhHkNL8w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/analytics": "0.10.7",
+        "@firebase/analytics-types": "0.8.2",
+        "@firebase/component": "0.6.8",
+        "@firebase/util": "1.9.7",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "@firebase/app-compat": "0.x"
+      }
+    },
+    "node_modules/@firebase/analytics-types": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/@firebase/analytics-types/-/analytics-types-0.8.2.tgz",
+      "integrity": "sha512-EnzNNLh+9/sJsimsA/FGqzakmrAUKLeJvjRHlg8df1f97NLUlFidk9600y0ZgWOp3CAxn6Hjtk+08tixlUOWyw==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@firebase/app": {
+      "version": "0.10.9",
+      "resolved": "https://registry.npmjs.org/@firebase/app/-/app-0.10.9.tgz",
+      "integrity": "sha512-AmGlPg/4SoDhwCdvVDeZsN5Yn+czYD/m/NAEOOCOhwn3Cz1xmEFKAKcyZKKahLrh5QPmge5Adyw+sk3cBTubBg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.6.8",
+        "@firebase/logger": "0.4.2",
+        "@firebase/util": "1.9.7",
+        "idb": "7.1.1",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@firebase/app-check": {
+      "version": "0.8.7",
+      "resolved": "https://registry.npmjs.org/@firebase/app-check/-/app-check-0.8.7.tgz",
+      "integrity": "sha512-EkOeJcMKVR0zZ6z/jqcFTqHb/xq+TVIRIuBNGHdpcIuFU1czhSlegvqv2+nC+nFrkD8M6Xvd3tAlUOkdbMeS6A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.6.8",
+        "@firebase/logger": "0.4.2",
+        "@firebase/util": "1.9.7",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "@firebase/app": "0.x"
+      }
+    },
+    "node_modules/@firebase/app-check-compat": {
+      "version": "0.3.14",
+      "resolved": "https://registry.npmjs.org/@firebase/app-check-compat/-/app-check-compat-0.3.14.tgz",
+      "integrity": "sha512-kK3bPfojAfXE53W+20rxMqIxrloFswXG9vh4kEdYL6Wa2IB3sD5++2dPiK3yGxl8oQiqS8qL2wcKB5/xLpEVEg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/app-check": "0.8.7",
+        "@firebase/app-check-types": "0.5.2",
+        "@firebase/component": "0.6.8",
+        "@firebase/logger": "0.4.2",
+        "@firebase/util": "1.9.7",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "@firebase/app-compat": "0.x"
+      }
+    },
+    "node_modules/@firebase/app-check-interop-types": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/@firebase/app-check-interop-types/-/app-check-interop-types-0.3.2.tgz",
+      "integrity": "sha512-LMs47Vinv2HBMZi49C09dJxp0QT5LwDzFaVGf/+ITHe3BlIhUiLNttkATSXplc89A2lAaeTqjgqVkiRfUGyQiQ==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@firebase/app-check-types": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/@firebase/app-check-types/-/app-check-types-0.5.2.tgz",
+      "integrity": "sha512-FSOEzTzL5bLUbD2co3Zut46iyPWML6xc4x+78TeaXMSuJap5QObfb+rVvZJtla3asN4RwU7elaQaduP+HFizDA==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@firebase/app-compat": {
+      "version": "0.2.39",
+      "resolved": "https://registry.npmjs.org/@firebase/app-compat/-/app-compat-0.2.39.tgz",
+      "integrity": "sha512-NnTFywe+M/jxZn751NIEhidgDePiDvlcfabvGxBy4YbU1E+b0TpEuJUnm3L6YDZtaZLVEz8ieoq9wbJkgGZ2rg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/app": "0.10.9",
+        "@firebase/component": "0.6.8",
+        "@firebase/logger": "0.4.2",
+        "@firebase/util": "1.9.7",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@firebase/app-types": {
+      "version": "0.9.2",
+      "resolved": "https://registry.npmjs.org/@firebase/app-types/-/app-types-0.9.2.tgz",
+      "integrity": "sha512-oMEZ1TDlBz479lmABwWsWjzHwheQKiAgnuKxE0pz0IXCVx7/rtlkx1fQ6GfgK24WCrxDKMplZrT50Kh04iMbXQ==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@firebase/auth": {
+      "version": "1.7.7",
+      "resolved": "https://registry.npmjs.org/@firebase/auth/-/auth-1.7.7.tgz",
+      "integrity": "sha512-gMB0uRRNiIvYorEDLtIq1mc7x5D080EsoghTIph9xnbLqcQS3qRBREEC2o21nMEhviAeiGJMelRkKhAkkggjmA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.6.8",
+        "@firebase/logger": "0.4.2",
+        "@firebase/util": "1.9.7",
+        "tslib": "^2.1.0",
+        "undici": "5.28.4"
+      },
+      "peerDependencies": {
+        "@firebase/app": "0.x",
+        "@react-native-async-storage/async-storage": "^1.18.1"
+      },
+      "peerDependenciesMeta": {
+        "@react-native-async-storage/async-storage": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@firebase/auth-compat": {
+      "version": "0.5.12",
+      "resolved": "https://registry.npmjs.org/@firebase/auth-compat/-/auth-compat-0.5.12.tgz",
+      "integrity": "sha512-K47inLqjTREez85D7pP0TmRv5aQcap22cJW67poLwJoJ6BVVH0I2NOfIoMqENetCrgGS+7vXSIZaLjvHFHwS+g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/auth": "1.7.7",
+        "@firebase/auth-types": "0.12.2",
+        "@firebase/component": "0.6.8",
+        "@firebase/util": "1.9.7",
+        "tslib": "^2.1.0",
+        "undici": "5.28.4"
+      },
+      "peerDependencies": {
+        "@firebase/app-compat": "0.x"
+      }
+    },
+    "node_modules/@firebase/auth-interop-types": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/@firebase/auth-interop-types/-/auth-interop-types-0.2.3.tgz",
+      "integrity": "sha512-Fc9wuJGgxoxQeavybiuwgyi+0rssr76b+nHpj+eGhXFYAdudMWyfBHvFL/I5fEHniUM/UQdFzi9VXJK2iZF7FQ==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@firebase/auth-types": {
+      "version": "0.12.2",
+      "resolved": "https://registry.npmjs.org/@firebase/auth-types/-/auth-types-0.12.2.tgz",
+      "integrity": "sha512-qsEBaRMoGvHO10unlDJhaKSuPn4pyoTtlQuP1ghZfzB6rNQPuhp/N/DcFZxm9i4v0SogjCbf9reWupwIvfmH6w==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "@firebase/app-types": "0.x",
+        "@firebase/util": "1.x"
+      }
+    },
+    "node_modules/@firebase/component": {
+      "version": "0.6.8",
+      "resolved": "https://registry.npmjs.org/@firebase/component/-/component-0.6.8.tgz",
+      "integrity": "sha512-LcNvxGLLGjBwB0dJUsBGCej2fqAepWyBubs4jt1Tiuns7QLbXHuyObZ4aMeBjZjWx4m8g1LoVI9QFpSaq/k4/g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/util": "1.9.7",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@firebase/database": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/@firebase/database/-/database-1.0.7.tgz",
+      "integrity": "sha512-wjXr5AO8RPxVVg7rRCYffT7FMtBjHRfJ9KMwi19MbOf0vBf0H9YqW3WCgcnLpXI6ehiUcU3z3qgPnnU0nK6SnA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/app-check-interop-types": "0.3.2",
+        "@firebase/auth-interop-types": "0.2.3",
+        "@firebase/component": "0.6.8",
+        "@firebase/logger": "0.4.2",
+        "@firebase/util": "1.9.7",
+        "faye-websocket": "0.11.4",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@firebase/database-compat": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/@firebase/database-compat/-/database-compat-1.0.7.tgz",
+      "integrity": "sha512-R/3B+VVzEFN5YcHmfWns3eitA8fHLTL03io+FIoMcTYkajFnrBdS3A+g/KceN9omP7FYYYGTQWF9lvbEx6eMEg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.6.8",
+        "@firebase/database": "1.0.7",
+        "@firebase/database-types": "1.0.4",
+        "@firebase/logger": "0.4.2",
+        "@firebase/util": "1.9.7",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@firebase/database-types": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@firebase/database-types/-/database-types-1.0.4.tgz",
+      "integrity": "sha512-mz9ZzbH6euFXbcBo+enuJ36I5dR5w+enJHHjy9Y5ThCdKUseqfDjW3vCp1YxE9zygFCSjJJ/z1cQ+zodvUcwPQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/app-types": "0.9.2",
+        "@firebase/util": "1.9.7"
+      }
+    },
+    "node_modules/@firebase/firestore": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/@firebase/firestore/-/firestore-4.7.0.tgz",
+      "integrity": "sha512-wGOp84P1qa1pfpdct6lckfyowTuvIlUDHoiRcN8dFDT4WnZDh0tZW1X77SMiBUVejK8xIRLBCK3yDTejlRVrUA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.6.8",
+        "@firebase/logger": "0.4.2",
+        "@firebase/util": "1.9.7",
+        "@firebase/webchannel-wrapper": "1.0.1",
+        "@grpc/grpc-js": "~1.9.0",
+        "@grpc/proto-loader": "^0.7.8",
+        "tslib": "^2.1.0",
+        "undici": "5.28.4"
+      },
+      "engines": {
+        "node": ">=10.10.0"
+      },
+      "peerDependencies": {
+        "@firebase/app": "0.x"
+      }
+    },
+    "node_modules/@firebase/firestore-compat": {
+      "version": "0.3.35",
+      "resolved": "https://registry.npmjs.org/@firebase/firestore-compat/-/firestore-compat-0.3.35.tgz",
+      "integrity": "sha512-VdYQtMIrPjsgZpuBwvry6LgcS0vbUhHzpebaKm5oc9oTTvP4K7oxvR/ZJdDjIE5rBugn1SdY++uGMatcIvBkZg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.6.8",
+        "@firebase/firestore": "4.7.0",
+        "@firebase/firestore-types": "3.0.2",
+        "@firebase/util": "1.9.7",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "@firebase/app-compat": "0.x"
+      }
+    },
+    "node_modules/@firebase/firestore-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@firebase/firestore-types/-/firestore-types-3.0.2.tgz",
+      "integrity": "sha512-wp1A+t5rI2Qc/2q7r2ZpjUXkRVPtGMd6zCLsiWurjsQpqPgFin3AhNibKcIzoF2rnToNa/XYtyWXuifjOOwDgg==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "@firebase/app-types": "0.x",
+        "@firebase/util": "1.x"
+      }
+    },
+    "node_modules/@firebase/functions": {
+      "version": "0.11.6",
+      "resolved": "https://registry.npmjs.org/@firebase/functions/-/functions-0.11.6.tgz",
+      "integrity": "sha512-GPfIBPtpwQvsC7SQbgaUjLTdja0CsNwMoKSgrzA1FGGRk4NX6qO7VQU6XCwBiAFWbpbQex6QWkSMsCzLx1uibQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/app-check-interop-types": "0.3.2",
+        "@firebase/auth-interop-types": "0.2.3",
+        "@firebase/component": "0.6.8",
+        "@firebase/messaging-interop-types": "0.2.2",
+        "@firebase/util": "1.9.7",
+        "tslib": "^2.1.0",
+        "undici": "5.28.4"
+      },
+      "peerDependencies": {
+        "@firebase/app": "0.x"
+      }
+    },
+    "node_modules/@firebase/functions-compat": {
+      "version": "0.3.12",
+      "resolved": "https://registry.npmjs.org/@firebase/functions-compat/-/functions-compat-0.3.12.tgz",
+      "integrity": "sha512-r3XUb5VlITWpML46JymfJPkK6I9j4SNlO7qWIXUc0TUmkv0oAfVoiIt1F83/NuMZXaGr4YWA/794nVSy4GV8tw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.6.8",
+        "@firebase/functions": "0.11.6",
+        "@firebase/functions-types": "0.6.2",
+        "@firebase/util": "1.9.7",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "@firebase/app-compat": "0.x"
+      }
+    },
+    "node_modules/@firebase/functions-types": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/@firebase/functions-types/-/functions-types-0.6.2.tgz",
+      "integrity": "sha512-0KiJ9lZ28nS2iJJvimpY4nNccV21rkQyor5Iheu/nq8aKXJqtJdeSlZDspjPSBBiHRzo7/GMUttegnsEITqR+w==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@firebase/installations": {
+      "version": "0.6.8",
+      "resolved": "https://registry.npmjs.org/@firebase/installations/-/installations-0.6.8.tgz",
+      "integrity": "sha512-57V374qdb2+wT5v7+ntpLXBjZkO6WRgmAUbVkRfFTM/4t980p0FesbqTAcOIiM8U866UeuuuF8lYH70D3jM/jQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.6.8",
+        "@firebase/util": "1.9.7",
+        "idb": "7.1.1",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "@firebase/app": "0.x"
+      }
+    },
+    "node_modules/@firebase/installations-compat": {
+      "version": "0.2.8",
+      "resolved": "https://registry.npmjs.org/@firebase/installations-compat/-/installations-compat-0.2.8.tgz",
+      "integrity": "sha512-pI2q8JFHB7yIq/szmhzGSWXtOvtzl6tCUmyykv5C8vvfOVJUH6mP4M4iwjbK8S1JotKd/K70+JWyYlxgQ0Kpyw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.6.8",
+        "@firebase/installations": "0.6.8",
+        "@firebase/installations-types": "0.5.2",
+        "@firebase/util": "1.9.7",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "@firebase/app-compat": "0.x"
+      }
+    },
+    "node_modules/@firebase/installations-types": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/@firebase/installations-types/-/installations-types-0.5.2.tgz",
+      "integrity": "sha512-que84TqGRZJpJKHBlF2pkvc1YcXrtEDOVGiDjovP/a3s6W4nlbohGXEsBJo0JCeeg/UG9A+DEZVDUV9GpklUzA==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "@firebase/app-types": "0.x"
+      }
+    },
+    "node_modules/@firebase/logger": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/@firebase/logger/-/logger-0.4.2.tgz",
+      "integrity": "sha512-Q1VuA5M1Gjqrwom6I6NUU4lQXdo9IAQieXlujeHZWvRt1b7qQ0KwBaNAjgxG27jgF9/mUwsNmO8ptBCGVYhB0A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@firebase/messaging": {
+      "version": "0.12.10",
+      "resolved": "https://registry.npmjs.org/@firebase/messaging/-/messaging-0.12.10.tgz",
+      "integrity": "sha512-fGbxJPKpl2DIKNJGhbk4mYPcM+qE2gl91r6xPoiol/mN88F5Ym6UeRdMVZah+pijh9WxM55alTYwXuW40r1Y2Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.6.8",
+        "@firebase/installations": "0.6.8",
+        "@firebase/messaging-interop-types": "0.2.2",
+        "@firebase/util": "1.9.7",
+        "idb": "7.1.1",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "@firebase/app": "0.x"
+      }
+    },
+    "node_modules/@firebase/messaging-compat": {
+      "version": "0.2.10",
+      "resolved": "https://registry.npmjs.org/@firebase/messaging-compat/-/messaging-compat-0.2.10.tgz",
+      "integrity": "sha512-FXQm7rcowkDm8kFLduHV35IRYCRo+Ng0PIp/t1+EBuEbyplaKkGjZ932pE+owf/XR+G/60ku2QRBptRGLXZydg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.6.8",
+        "@firebase/messaging": "0.12.10",
+        "@firebase/util": "1.9.7",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "@firebase/app-compat": "0.x"
+      }
+    },
+    "node_modules/@firebase/messaging-interop-types": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/@firebase/messaging-interop-types/-/messaging-interop-types-0.2.2.tgz",
+      "integrity": "sha512-l68HXbuD2PPzDUOFb3aG+nZj5KA3INcPwlocwLZOzPp9rFM9yeuI9YLl6DQfguTX5eAGxO0doTR+rDLDvQb5tA==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@firebase/performance": {
+      "version": "0.6.8",
+      "resolved": "https://registry.npmjs.org/@firebase/performance/-/performance-0.6.8.tgz",
+      "integrity": "sha512-F+alziiIZ6Yn8FG47mxwljq+4XkgkT2uJIFRlkyViUQRLzrogaUJW6u/+6ZrePXnouKlKIwzqos3PVJraPEcCA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.6.8",
+        "@firebase/installations": "0.6.8",
+        "@firebase/logger": "0.4.2",
+        "@firebase/util": "1.9.7",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "@firebase/app": "0.x"
+      }
+    },
+    "node_modules/@firebase/performance-compat": {
+      "version": "0.2.8",
+      "resolved": "https://registry.npmjs.org/@firebase/performance-compat/-/performance-compat-0.2.8.tgz",
+      "integrity": "sha512-o7TFClRVJd3VIBoY7KZQqtCeW0PC6v9uBzM6Lfw3Nc9D7hM6OonqecYvh7NwJ6R14k+xM27frLS4BcCvFHKw2A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.6.8",
+        "@firebase/logger": "0.4.2",
+        "@firebase/performance": "0.6.8",
+        "@firebase/performance-types": "0.2.2",
+        "@firebase/util": "1.9.7",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "@firebase/app-compat": "0.x"
+      }
+    },
+    "node_modules/@firebase/performance-types": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/@firebase/performance-types/-/performance-types-0.2.2.tgz",
+      "integrity": "sha512-gVq0/lAClVH5STrIdKnHnCo2UcPLjJlDUoEB/tB4KM+hAeHUxWKnpT0nemUPvxZ5nbdY/pybeyMe8Cs29gEcHA==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@firebase/remote-config": {
+      "version": "0.4.8",
+      "resolved": "https://registry.npmjs.org/@firebase/remote-config/-/remote-config-0.4.8.tgz",
+      "integrity": "sha512-AMLqe6wfIRnjc6FkCWOSUjhc1fSTEf8o+cv1NolFvbiJ/tU+TqN4pI7pT+MIKQzNiq5fxLehkOx+xtAQBxPJKQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.6.8",
+        "@firebase/installations": "0.6.8",
+        "@firebase/logger": "0.4.2",
+        "@firebase/util": "1.9.7",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "@firebase/app": "0.x"
+      }
+    },
+    "node_modules/@firebase/remote-config-compat": {
+      "version": "0.2.8",
+      "resolved": "https://registry.npmjs.org/@firebase/remote-config-compat/-/remote-config-compat-0.2.8.tgz",
+      "integrity": "sha512-UxSFOp6dzFj2AHB8Bq/BYtbq5iFyizKx4Rd6WxAdaKYM8cnPMeK+l2v+Oogtjae+AeyHRI+MfL2acsfVe5cd2A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.6.8",
+        "@firebase/logger": "0.4.2",
+        "@firebase/remote-config": "0.4.8",
+        "@firebase/remote-config-types": "0.3.2",
+        "@firebase/util": "1.9.7",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "@firebase/app-compat": "0.x"
+      }
+    },
+    "node_modules/@firebase/remote-config-types": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/@firebase/remote-config-types/-/remote-config-types-0.3.2.tgz",
+      "integrity": "sha512-0BC4+Ud7y2aPTyhXJTMTFfrGGLqdYXrUB9sJVAB8NiqJswDTc4/2qrE/yfUbnQJhbSi6ZaTTBKyG3n1nplssaA==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@firebase/storage": {
+      "version": "0.13.0",
+      "resolved": "https://registry.npmjs.org/@firebase/storage/-/storage-0.13.0.tgz",
+      "integrity": "sha512-3RQaYpkR4TwPnPR1XlmDUAXiYt5QVQRGRGY1+/yNyS9ohHOCNNgbcs6a+QYvaDInbYTywrdddKYMFFXKKb1pRg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.6.8",
+        "@firebase/util": "1.9.7",
+        "tslib": "^2.1.0",
+        "undici": "5.28.4"
+      },
+      "peerDependencies": {
+        "@firebase/app": "0.x"
+      }
+    },
+    "node_modules/@firebase/storage-compat": {
+      "version": "0.3.10",
+      "resolved": "https://registry.npmjs.org/@firebase/storage-compat/-/storage-compat-0.3.10.tgz",
+      "integrity": "sha512-KcikeV5dK1H1cXi0zEb7gJ3IZ4dKKCjpyucVK8r/Qv5eNAqeQAzPgKKhsSv67wT1N6DTxmqsNEXwMo0dcrKOEg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.6.8",
+        "@firebase/storage": "0.13.0",
+        "@firebase/storage-types": "0.8.2",
+        "@firebase/util": "1.9.7",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "@firebase/app-compat": "0.x"
+      }
+    },
+    "node_modules/@firebase/storage-types": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/@firebase/storage-types/-/storage-types-0.8.2.tgz",
+      "integrity": "sha512-0vWu99rdey0g53lA7IShoA2Lol1jfnPovzLDUBuon65K7uKG9G+L5uO05brD9pMw+l4HRFw23ah3GwTGpEav6g==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "@firebase/app-types": "0.x",
+        "@firebase/util": "1.x"
+      }
+    },
+    "node_modules/@firebase/util": {
+      "version": "1.9.7",
+      "resolved": "https://registry.npmjs.org/@firebase/util/-/util-1.9.7.tgz",
+      "integrity": "sha512-fBVNH/8bRbYjqlbIhZ+lBtdAAS4WqZumx03K06/u7fJSpz1TGjEMm1ImvKD47w+xaFKIP2ori6z8BrbakRfjJA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@firebase/vertexai-preview": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/@firebase/vertexai-preview/-/vertexai-preview-0.0.3.tgz",
+      "integrity": "sha512-KVtUWLp+ScgiwkDKAvNkVucAyhLVQp6C6lhnVEuIg4mWhWcS3oerjAeVhZT4uNofKwWxRsOaB2Yec7DMTXlQPQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/app-check-interop-types": "0.3.2",
+        "@firebase/component": "0.6.8",
+        "@firebase/logger": "0.4.2",
+        "@firebase/util": "1.9.7",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "@firebase/app": "0.x",
+        "@firebase/app-types": "0.x"
+      }
+    },
+    "node_modules/@firebase/webchannel-wrapper": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@firebase/webchannel-wrapper/-/webchannel-wrapper-1.0.1.tgz",
+      "integrity": "sha512-jmEnr/pk0yVkA7mIlHNnxCi+wWzOFUg0WyIotgkKAb2u1J7fAeDBcVNSTjTihbAYNusCLQdW5s9IJ5qwnEufcQ==",
+      "license": "Apache-2.0"
+    },
     "node_modules/@floating-ui/core": {
       "version": "1.6.4",
       "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.6.4.tgz",
@@ -925,6 +1482,37 @@
       "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.4.tgz",
       "integrity": "sha512-dWO2pw8hhi+WrXq1YJy2yCuWoL20PddgGaqTgVe4cOS9Q6qklXCiA1tJEqX6BEwRNSCP84/afac9hd4MS+zEUA==",
       "license": "MIT"
+    },
+    "node_modules/@grpc/grpc-js": {
+      "version": "1.9.15",
+      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.9.15.tgz",
+      "integrity": "sha512-nqE7Hc0AzI+euzUwDAy0aY5hCp10r734gMGRdU+qOPX0XSceI2ULrcXB5U2xSc5VkWwalCj4M7GzCAygZl2KoQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@grpc/proto-loader": "^0.7.8",
+        "@types/node": ">=12.12.47"
+      },
+      "engines": {
+        "node": "^8.13.0 || >=10.10.0"
+      }
+    },
+    "node_modules/@grpc/proto-loader": {
+      "version": "0.7.13",
+      "resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.7.13.tgz",
+      "integrity": "sha512-AiXO/bfe9bmxBjxxtYxFAXGZvMaN5s8kO+jBHAJCON8rJoB5YS/D6X7ZNc6XQkuHNmyl4CYaMI1fJ/Gn27RGGw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "lodash.camelcase": "^4.3.0",
+        "long": "^5.0.0",
+        "protobufjs": "^7.2.5",
+        "yargs": "^17.7.2"
+      },
+      "bin": {
+        "proto-loader-gen-types": "build/bin/proto-loader-gen-types.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
     },
     "node_modules/@humanwhocodes/config-array": {
       "version": "0.11.14",
@@ -1067,6 +1655,70 @@
       "funding": {
         "url": "https://opencollective.com/unts"
       }
+    },
+    "node_modules/@protobufjs/aspromise": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
+      "integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/base64": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
+      "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/codegen": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.4.tgz",
+      "integrity": "sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/eventemitter": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz",
+      "integrity": "sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/fetch": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.0.tgz",
+      "integrity": "sha512-lljVXpqXebpsijW71PZaCYeIcE5on1w5DlQy5WH6GLbFryLUrBD4932W/E2BSpfRJWseIL4v/KPgBFxDOIdKpQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.1",
+        "@protobufjs/inquire": "^1.1.0"
+      }
+    },
+    "node_modules/@protobufjs/float": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
+      "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/inquire": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.0.tgz",
+      "integrity": "sha512-kdSefcPdruJiFMVSbn801t4vFK7KB/5gd2fYvrxhuJYg8ILrmn9SKSX2tZdV6V+ksulWqS7aXjBcRXl3wHoD9Q==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/path": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
+      "integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/pool": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
+      "integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/utf8": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
+      "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/@remix-run/router": {
       "version": "1.18.0",
@@ -1587,6 +2239,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/node": {
+      "version": "22.5.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.5.0.tgz",
+      "integrity": "sha512-DkFrJOe+rfdHTqqMg0bSNlGlQ85hSoh2TPzZyhHsXnMtligRWpxUySiyw8FY14ITt24HVCiQPWxS3KO/QlGmWg==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.19.2"
+      }
+    },
     "node_modules/@types/prop-types": {
       "version": "15.7.12",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.12.tgz",
@@ -1728,7 +2389,6 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -2107,6 +2767,99 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/cliui": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.1",
+        "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/cliui/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/cliui/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/cliui/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "license": "MIT"
+    },
+    "node_modules/cliui/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "license": "MIT"
+    },
+    "node_modules/cliui/node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cliui/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cliui/node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
       }
     },
     "node_modules/clsx": {
@@ -2619,7 +3372,6 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.2.tgz",
       "integrity": "sha512-ErCHMCae19vR8vQGe50xIsVomy19rg6gFu3+r3jkEO46suLMWBksvVyoGgQV+jOfl84ZSOSlmv6Gxa89PmTGmA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -3088,6 +3840,18 @@
         "reusify": "^1.0.4"
       }
     },
+    "node_modules/faye-websocket": {
+      "version": "0.11.4",
+      "resolved": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.11.4.tgz",
+      "integrity": "sha512-CzbClwlXAuiRQAlUyfqPgvPoNKTckTPGfwZV4ZdAhVcP2lh9KUxJg2b5GkE7XbjKQ3YJnQ9z6D9ntLAlB+tP8g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "websocket-driver": ">=0.5.1"
+      },
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
     "node_modules/file-entry-cache": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.1.tgz",
@@ -3129,6 +3893,41 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/firebase": {
+      "version": "10.13.0",
+      "resolved": "https://registry.npmjs.org/firebase/-/firebase-10.13.0.tgz",
+      "integrity": "sha512-a8gm8c9CYO98QuXJn7m5W5Gj7kHV8fme81/mQ9dBs+VMz9uI5HdavnMVPXCILputpZFMFpiKK+u7VVsn5lQg+w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/analytics": "0.10.7",
+        "@firebase/analytics-compat": "0.2.13",
+        "@firebase/app": "0.10.9",
+        "@firebase/app-check": "0.8.7",
+        "@firebase/app-check-compat": "0.3.14",
+        "@firebase/app-compat": "0.2.39",
+        "@firebase/app-types": "0.9.2",
+        "@firebase/auth": "1.7.7",
+        "@firebase/auth-compat": "0.5.12",
+        "@firebase/database": "1.0.7",
+        "@firebase/database-compat": "1.0.7",
+        "@firebase/firestore": "4.7.0",
+        "@firebase/firestore-compat": "0.3.35",
+        "@firebase/functions": "0.11.6",
+        "@firebase/functions-compat": "0.3.12",
+        "@firebase/installations": "0.6.8",
+        "@firebase/installations-compat": "0.2.8",
+        "@firebase/messaging": "0.12.10",
+        "@firebase/messaging-compat": "0.2.10",
+        "@firebase/performance": "0.6.8",
+        "@firebase/performance-compat": "0.2.8",
+        "@firebase/remote-config": "0.4.8",
+        "@firebase/remote-config-compat": "0.2.8",
+        "@firebase/storage": "0.13.0",
+        "@firebase/storage-compat": "0.3.10",
+        "@firebase/util": "1.9.7",
+        "@firebase/vertexai-preview": "0.0.3"
       }
     },
     "node_modules/flat-cache": {
@@ -3232,6 +4031,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "license": "ISC",
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
       }
     },
     "node_modules/get-intrinsic": {
@@ -3469,6 +4277,12 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/http-parser-js": {
+      "version": "0.5.8",
+      "resolved": "https://registry.npmjs.org/http-parser-js/-/http-parser-js-0.5.8.tgz",
+      "integrity": "sha512-SGeBX54F94Wgu5RH3X5jsDtf4eHyRogWX1XGT3b4HuW3tQPM4AaBzoUji/4AAJNXCEOWZ5O0DgZmJw1947gD5Q==",
+      "license": "MIT"
+    },
     "node_modules/human-signals": {
       "version": "4.3.1",
       "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-4.3.1.tgz",
@@ -3494,6 +4308,12 @@
       "funding": {
         "url": "https://github.com/sponsors/typicode"
       }
+    },
+    "node_modules/idb": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/idb/-/idb-7.1.1.tgz",
+      "integrity": "sha512-gchesWBzyvGHRO9W8tzUWFDycow5gwjvFKfyV9FF32Y7F50yZMp7mP+T2mJIWFx49zicqyC4uefHM17o6xKIVQ==",
+      "license": "ISC"
     },
     "node_modules/ignore": {
       "version": "5.3.1",
@@ -4251,6 +5071,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/lodash.camelcase": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
+      "integrity": "sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==",
+      "license": "MIT"
+    },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
@@ -4306,6 +5132,12 @@
       "funding": {
         "url": "https://github.com/chalk/strip-ansi?sponsor=1"
       }
+    },
+    "node_modules/long": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/long/-/long-5.2.3.tgz",
+      "integrity": "sha512-lcHwpNoggQTObv5apGNCTdJrO69eHOZMi4BNC+rTLER8iHAqGrUVeLh/irVIM7zTw2bOXA8T6uNPeujwOLg/2Q==",
+      "license": "Apache-2.0"
     },
     "node_modules/loose-envify": {
       "version": "1.4.0",
@@ -4907,6 +5739,30 @@
         "react-is": "^16.13.1"
       }
     },
+    "node_modules/protobufjs": {
+      "version": "7.4.0",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.4.0.tgz",
+      "integrity": "sha512-mRUWCc3KUU4w1jU8sGxICXH/gNS94DvI1gxqDvBzhj1JpcsimQkYiOJfwsPUykUI5ZaspFbSgmBLER8IrQ3tqw==",
+      "hasInstallScript": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.2",
+        "@protobufjs/base64": "^1.1.2",
+        "@protobufjs/codegen": "^2.0.4",
+        "@protobufjs/eventemitter": "^1.1.0",
+        "@protobufjs/fetch": "^1.1.0",
+        "@protobufjs/float": "^1.0.2",
+        "@protobufjs/inquire": "^1.1.0",
+        "@protobufjs/path": "^1.1.2",
+        "@protobufjs/pool": "^1.1.0",
+        "@protobufjs/utf8": "^1.1.0",
+        "@types/node": ">=13.7.0",
+        "long": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
     "node_modules/punycode": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -5087,6 +5943,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/resolve": {
@@ -5273,6 +6138,26 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/safe-regex-test": {
       "version": "1.0.3",
@@ -5588,7 +6473,6 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-regex": "^5.0.1"
@@ -5770,7 +6654,6 @@
       "version": "2.6.3",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.3.tgz",
       "integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ==",
-      "dev": true,
       "license": "0BSD"
     },
     "node_modules/type-check": {
@@ -5892,6 +6775,24 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/undici": {
+      "version": "5.28.4",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-5.28.4.tgz",
+      "integrity": "sha512-72RFADWFqKmUb2hmmvNODKL3p9hcB6Gt2DOQMis1SEBaV6a4MH8soBvzg+95CYhCKPFedut2JY9bMfrDl9D23g==",
+      "license": "MIT",
+      "dependencies": {
+        "@fastify/busboy": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14.0"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.19.8",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
+      "integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==",
+      "license": "MIT"
+    },
     "node_modules/update-browserslist-db": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.1.0.tgz",
@@ -6009,6 +6910,29 @@
       "integrity": "sha512-rpJyN222KWIvHJ/F53XSZv0Zl/accqHR8et1kpaMTD/fLCRxtV8iX8czMzY7sVZupTI3zcUTg8eycS2kNF9l6w==",
       "dependencies": {
         "loose-envify": "^1.0.0"
+      }
+    },
+    "node_modules/websocket-driver": {
+      "version": "0.7.4",
+      "resolved": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.7.4.tgz",
+      "integrity": "sha512-b17KeDIQVjvb0ssuSDF2cYXSg2iztliJ4B9WdsuB6J952qCPKmnVq4DyW5motImXHDC1cBT/1UezrJVsKw5zjg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "http-parser-js": ">=0.5.1",
+        "safe-buffer": ">=5.1.0",
+        "websocket-extensions": ">=0.1.1"
+      },
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/websocket-extensions": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/websocket-extensions/-/websocket-extensions-0.1.4.tgz",
+      "integrity": "sha512-OqedPIGOfsDlo31UNwYbCFMSaO9m9G/0faIHj5/dZFDMFqPTcx6UwqyOy3COEaEOg/9VsGIpdqn62W5KhoKSpg==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.8.0"
       }
     },
     "node_modules/which": {
@@ -6187,6 +7111,15 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/yallist": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
@@ -6202,6 +7135,62 @@
       "license": "ISC",
       "engines": {
         "node": ">= 14"
+      }
+    },
+    "node_modules/yargs": {
+      "version": "17.7.2",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
+      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^8.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.3",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^21.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yargs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "license": "MIT"
+    },
+    "node_modules/yargs/node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/yargs/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/yocto-queue": {

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "postinstall": "husky install"
   },
   "dependencies": {
+    "firebase": "^10.13.0",
     "jotai": "^2.9.0",
     "react": "^18.3.1",
     "react-calendar": "^5.0.0",

--- a/src/apis/loadUserData.js
+++ b/src/apis/loadUserData.js
@@ -1,0 +1,15 @@
+import { doc, getDoc } from "firebase/firestore";
+
+// 저장된 데이터 불러오기
+const loadUserData = async (userName) => {
+  const docRef = doc(db, "users", userName);
+  const docSnap = await getDoc(docRef);
+
+  if (docSnap.exists()) {
+    // console.log("Document data:", docSnap.data());
+    return docSnap.data();
+  } else {
+    // console.log("No such document!");
+    return null;
+  }
+};

--- a/src/apis/saveUserData.js
+++ b/src/apis/saveUserData.js
@@ -1,0 +1,25 @@
+import { doc, setDoc } from "firebase/firestore";
+import { useAtomValue } from "jotai";
+import { userNameAtom, themeSiteAtom, minuteCountAtom } from "../../store/atom";
+import { db } from "../../firebase-config";
+
+// 데이터 저장
+const saveUserData = async () => {
+  const userName = useAtomValue(userNameAtom);
+  const themeSite = useAtomValue(themeSiteAtom);
+  const timeSpent = useAtomValue(minuteCountAtom);
+
+  if (userName && themeSite) {
+    try {
+      await setDoc(doc(db, "users", userName), {
+        themeSite: themeSite,
+        timeSpent: timeSpent
+      });
+      // console.log("데이터가 저장되었습니다.");
+    } catch (e) {
+      console.error("데이터 저장 실패: ", e);
+    }
+  }
+};
+
+export default saveUserData;

--- a/src/apis/saveUserData.js
+++ b/src/apis/saveUserData.js
@@ -1,24 +1,51 @@
-import { doc, setDoc } from "firebase/firestore";
-import { useAtomValue } from "jotai";
-import { userNameAtom, themeSiteAtom, minuteCountAtom } from "../../store/atom";
+import { collection, addDoc } from "firebase/firestore";
 import { db } from "../../firebase-config";
+import { FirebaseError } from "firebase/app";
+import { Timestamp } from "@firebase/firestore";
 
 // 데이터 저장
-const saveUserData = async () => {
-  const userName = useAtomValue(userNameAtom);
-  const themeSite = useAtomValue(themeSiteAtom);
-  const timeSpent = useAtomValue(minuteCountAtom);
-
+const saveUserData = async (userName, themeSite, timeSpent) => {
+  //저장할 데이터
+  const data = {
+    userName: userName,
+    themeSite: themeSite,
+    timeSpent: timeSpent,
+    timeStamp: Timestamp.fromDate(new Date())
+  };
   if (userName && themeSite) {
     try {
-      await setDoc(doc(db, "users", userName), {
-        themeSite: themeSite,
-        timeSpent: timeSpent
-      });
-      // console.log("데이터가 저장되었습니다.");
+      await addDoc(collection(db, "users"), data);
+      sessionStorage.setItem("record", data);
+      console.log(`저장된 데이터 : ${JSON.stringify(data, null, 2)}`);
     } catch (e) {
-      console.error("데이터 저장 실패: ", e);
+      if (e instanceof FirebaseError) {
+        // Firebase에서 발생한 오류 처리
+        console.error("Firebase 오류:", e.code, e.message);
+        switch (e.code) {
+          case "permission-denied":
+            console.error("권한이 없습니다. 데이터를 저장할 수 없습니다.");
+            break;
+          case "unavailable":
+            console.error(
+              "서비스가 현재 이용 불가능합니다. 나중에 다시 시도해주세요."
+            );
+            break;
+          // 필요한 경우 다른 Firebase 오류 코드 추가
+          default:
+            console.error("알 수 없는 Firebase 오류가 발생했습니다.");
+        }
+      } else if (e instanceof TypeError) {
+        // 타입 관련 오류 처리
+        console.error("타입 오류:", e.message);
+      } else {
+        // 기타 오류 처리
+        console.error("예상치 못한 오류:", e.message);
+      }
     }
+  } else {
+    console.error(
+      "유효하지 않은 입력 값입니다. userName과 themeSite가 필요합니다."
+    );
   }
 };
 

--- a/src/components/forms/pay/DetailPayForm.jsx
+++ b/src/components/forms/pay/DetailPayForm.jsx
@@ -2,7 +2,7 @@ import styled from "styled-components";
 import { FormWrap } from "../FormStyle";
 import Input from "../../input/Input";
 import { useAtomValue } from "jotai";
-import { levelAtom } from "../../../store/atom";
+import { levelAtom, themeSiteAtom } from "../../../store/atom";
 import AnimationArea from "../../Animation";
 const DetailPayFormWrap = styled(FormWrap)`
   flex-direction: row;
@@ -53,7 +53,9 @@ const DetailPayForm = ({
   hasPayFormError,
   cardTypesError
 }) => {
+  //레벨 및 연습모드 여부
   const level = useAtomValue(levelAtom);
+  const isPractice = useAtomValue(themeSiteAtom) === "practice";
   return (
     <DetailPayFormWrap $hasPayFormError={hasPayFormError}>
       <FormWrap>
@@ -65,7 +67,7 @@ const DetailPayForm = ({
             value={payItem}
             text={payItem}
             onChange={handleChange}
-            $focus={level === "low" && index == 0 && !isSelected}
+            $focus={level === "low" && isPractice && index == 0 && !isSelected}
           />
         ))}
       </FormWrap>

--- a/src/components/forms/pay/PayMethodForm.jsx
+++ b/src/components/forms/pay/PayMethodForm.jsx
@@ -1,7 +1,7 @@
 import { FormWrap } from "../FormStyle";
 import Input from "../../input/Input";
 import { useAtomValue } from "jotai";
-import { levelAtom } from "../../../store/atom";
+import { levelAtom, themeSiteAtom } from "../../../store/atom";
 
 const textArr = [
   "신용카드",
@@ -12,9 +12,9 @@ const textArr = [
 ];
 //선택되었다면 애니메이션 끄기
 const PayMethodForm = ({ handleChange, isSelected }) => {
-  //level에 따라 animation 설정
+  //레벨 및 연습모드 여부
   const level = useAtomValue(levelAtom);
-
+  const isPractice = useAtomValue(themeSiteAtom) === "practice";
   return (
     <FormWrap>
       {textArr.map((methodItem, index) => (
@@ -25,7 +25,7 @@ const PayMethodForm = ({ handleChange, isSelected }) => {
           value={methodItem}
           text={methodItem}
           onChange={handleChange}
-          $focus={level === "low" && index === 0 && !isSelected}
+          $focus={level === "low" && isPractice && index === 0 && !isSelected}
         />
       ))}
     </FormWrap>

--- a/src/components/forms/ticket/TicketBuyer.jsx
+++ b/src/components/forms/ticket/TicketBuyer.jsx
@@ -1,12 +1,8 @@
 import styled from "styled-components";
 import { FormWrap } from "../FormStyle";
 import { InputContainer, Label } from "../../input/InputStyle";
-import { useAtomValue, useSetAtom } from "jotai";
-import {
-  levelAtom,
-  ticketBuyerBirthAtom,
-  userNameAtom
-} from "../../../store/atom";
+import { useAtomValue } from "jotai";
+import { levelAtom, userNameAtom } from "../../../store/atom";
 
 const BuyerWrap = styled.div`
   display: flex;

--- a/src/components/forms/ticket/TicketBuyer.jsx
+++ b/src/components/forms/ticket/TicketBuyer.jsx
@@ -1,9 +1,12 @@
 import styled from "styled-components";
 import { FormWrap } from "../FormStyle";
 import { InputContainer, Label } from "../../input/InputStyle";
-import { useAtomValue } from "jotai";
-import { levelAtom, userNameAtom } from "../../../store/atom";
-import { useState } from "react";
+import { useAtomValue, useSetAtom } from "jotai";
+import {
+  levelAtom,
+  ticketBuyerBirthAtom,
+  userNameAtom
+} from "../../../store/atom";
 
 const BuyerWrap = styled.div`
   display: flex;
@@ -63,14 +66,14 @@ const data_delivery = [
 
 const TicketBuyer = ({ option, setIsValidate, errorArray }) => {
   const userName = useAtomValue(userNameAtom);
+
   //난이도 - 생년월일 입력 구현
   const level = useAtomValue(levelAtom);
   // 생년월일 입력 검사 로직
-  const [birth, setBirth] = useState("");
   const handleChange = (e) => {
     const value = e.target.value;
-    // 생년월일이 비어있거나 길이가 8이 아닌 경우 에러
-    if (value === "" || value.length !== 8) {
+    // 생년월일이 비어있거나 길이가 6이 아닌 경우 에러
+    if (value === "" || value.length !== 6) {
       setIsValidate((prev) => prev.filter((item) => item !== "birth"));
     } else {
       setIsValidate((prev) =>
@@ -92,7 +95,7 @@ const TicketBuyer = ({ option, setIsValidate, errorArray }) => {
                   name="birth"
                   type="number"
                   onChange={handleChange}
-                  placeholder="생년월일 예시 : 20010111"
+                  placeholder="생년월일 예시 : 990101"
                   $hasError={hasError}
                 ></InfoInput>
               ) : (

--- a/src/components/forms/ticket/TicketMethod.jsx
+++ b/src/components/forms/ticket/TicketMethod.jsx
@@ -2,12 +2,14 @@ import styled from "styled-components";
 import Input from "../../input/Input";
 import { FormWrap } from "../FormStyle";
 import TicketBuyer from "./TicketBuyer";
-import { useState } from "react";
 
 const SectionTitle = styled.div`
+  width: ${(props) => (props.$option === "현장수령" ? "500px" : "800px")};
   font-size: 20px;
   font-family: "pretendardB";
   margin-bottom: 20px;
+  padding: 10px 0;
+  border-bottom: 1px solid var(--fill-color);
 `;
 const TicketMethodCont = styled.div`
   display: flex;
@@ -15,14 +17,12 @@ const TicketMethodCont = styled.div`
   color: ${(props) => props.$hasError && "var(--point-color)"};
 `;
 const TicketMethodWrap = styled(FormWrap)`
-  border: 2px solid var(--fill-color);
   border-radius: 8px;
   display: inline-flex;
   flex-direction: column;
   gap: 50px;
   justify-content: center;
   align-items: start;
-  padding: 20px;
   height: 417px;
 `;
 const TicketMethod = ({ option, setOption, setIsValidate, errorArray }) => {
@@ -43,7 +43,7 @@ const TicketMethod = ({ option, setOption, setIsValidate, errorArray }) => {
     <TicketMethodWrap>
       {/*티켓수령방법 */}
       <TicketMethodCont $hasError={hasError}>
-        <SectionTitle>티켓수령방법</SectionTitle>
+        <SectionTitle $option={option}>티켓수령방법</SectionTitle>
         <Input
           type="radio"
           value="현장수령"
@@ -61,7 +61,7 @@ const TicketMethod = ({ option, setOption, setIsValidate, errorArray }) => {
       </TicketMethodCont>
       <TicketMethodCont>
         {/*예매자 확인 */}
-        <SectionTitle>예매자 확인</SectionTitle>
+        <SectionTitle $option={option}>예매자 확인</SectionTitle>
         <TicketBuyer
           option={option}
           setIsValidate={setIsValidate}

--- a/src/components/header/Header.jsx
+++ b/src/components/header/Header.jsx
@@ -46,6 +46,7 @@ const Header = () => {
       return;
     }
     //location에 step을 포함한 경우 : 예매를 진행 중인 경우
+    //타이머 멈추고 모달창 띄움
     setTimerControl(() => true);
     setIsConfirm(true);
   };

--- a/src/components/header/nav/Nav.jsx
+++ b/src/components/header/nav/Nav.jsx
@@ -2,6 +2,7 @@ import React from "react";
 import styled, { css } from "styled-components"; // css 함수 import 추가
 import SubNav from "./subNav/SubNav";
 import useHover from "../../../hooks/useHover";
+import { useNavigate } from "react-router-dom";
 
 /*네비게이터 전체 */
 const NavBorderBottom = styled.div`
@@ -87,7 +88,7 @@ const Nav = () => {
     handleMouseLeave,
     handleMouseEnter
   } = useHover();
-
+  const nav = useNavigate();
   return (
     <NavBorderBottom>
       <NavWrap>
@@ -109,6 +110,7 @@ const Nav = () => {
               $ishovered={ishovered}
               $isactive={hovereditem === "실전모드"}
               onMouseEnter={() => handleHoveredItemEnter("실전모드")}
+              onClick={() => nav("/record")}
             >
               실전 모드
             </NavContent>

--- a/src/components/header/nav/subNav/SubNav.jsx
+++ b/src/components/header/nav/subNav/SubNav.jsx
@@ -7,7 +7,7 @@ import {
   userNameErrorAtom
 } from "../../../../store/atom";
 import { useAtomValue, useSetAtom } from "jotai";
-
+import resetAtom from "../../../../util/resetAtom";
 const SubNavBgc = styled.div`
   width: 100vw;
   height: 45px;
@@ -61,9 +61,11 @@ const SubNav = ({ hovereditem }) => {
       return;
     }
     if (location === "low" || location === "middle" || location === "high") {
+      resetAtom();
       setLevel(location); // 레벨 설정
       nav("/progress/step0"); // 연습모드 step0로 이동
     } else {
+      resetAtom();
       setThemeSite(location); // 테마 사이트 설정
       nav(`/challenge/${location}/step0`); // 각 사이트의 인트로 페이지로 이동
     }

--- a/src/components/modal/GoToMainModalCont.jsx
+++ b/src/components/modal/GoToMainModalCont.jsx
@@ -3,6 +3,7 @@ import Button from "../button/Button";
 import { useNavigate } from "react-router-dom";
 import { useSetAtom } from "jotai";
 import { timerControlAtom } from "../../store/atom";
+import resetAtom from "../../util/resetAtom";
 
 const Container = styled.div`
   display: flex;
@@ -31,9 +32,10 @@ const GoToMainModalCont = ({ setIsConfirm }) => {
   const handleClick = (confirmNavigate) => {
     //확인을 누를 경우
     if (confirmNavigate) {
-      navigate("/");
       setTimerControl(() => false);
       setIsConfirm(() => false);
+      resetAtom();
+      navigate("/");
       return;
     }
     //취소를 누를 경우

--- a/src/components/myBookingInfo/MyBookingInfo.jsx
+++ b/src/components/myBookingInfo/MyBookingInfo.jsx
@@ -1,47 +1,43 @@
 import styled from "styled-components";
-import {
-  allowedSeatAtom,
-  seatCountAtom,
-  levelAtom,
-  seatInfoAtom
-} from "../../store/atom";
+import { allowedSeatAtom, seatCountAtom, seatInfoAtom } from "../../store/atom";
 import { useAtomValue } from "jotai";
-import { useEffect, useState } from "react";
 
 const Container = styled.div`
-  border: 2px solid var(--fill-color);
   border-radius: 8px;
   width: 400px;
   display: flex;
+  gap: 15px;
   flex-direction: column;
-  justify-content: space-between;
-  padding: 60px 20px;
+  align-items: center;
 `;
 
 const Title = styled.div`
+  width: 100%;
   font-family: "pretendardB";
   margin-bottom: 20px;
 `;
 
 const InfoContainer = styled.div`
+  width: 100%;
   display: flex;
   flex-direction: column;
 `;
 const InfoItem = styled.div`
   display: flex;
-  justify-content: space-between;
   margin: 10px 0;
 `;
 const InfoTitle = styled.span`
   color: var(--text-color);
   font-family: "pretendardB";
   font-size: 16px;
+  flex: 1;
 `;
 const InfoText = styled.div`
   font-family: "pretendardB";
   font-size: 16px;
 `;
 const TotalAmount = styled.div`
+  width: 100%;
   display: flex;
   justify-content: space-between;
   border-top: 2px solid var(--fill-color);
@@ -60,7 +56,6 @@ const MyBookingInfo = ({ option }) => {
   const allowedSeat = useAtomValue(allowedSeatAtom);
   const seatCount = useAtomValue(seatCountAtom);
   const seatInfo = useAtomValue(seatInfoAtom);
-  const level = useAtomValue(levelAtom);
 
   const Info = [
     // 공연 날짜 및 시간

--- a/src/components/myBookingInfo/MyBookingInfo.jsx
+++ b/src/components/myBookingInfo/MyBookingInfo.jsx
@@ -99,7 +99,6 @@ const MyBookingInfo = ({
     { title: "쿠폰할인", price: 0 }
   ];
   const nav = useNavigate();
-  const themeSite = useAtomValue(themeSiteAtom);
 
   const handleButtonClick = () => {
     // 좌석 매수가 0일 경우 경고창 출력

--- a/src/components/myBookingInfo/MyBookingInfo.jsx
+++ b/src/components/myBookingInfo/MyBookingInfo.jsx
@@ -1,37 +1,31 @@
 import styled from "styled-components";
-import Button from "../button/Button";
-import Animation from "../Animation";
 import {
   allowedSeatAtom,
   seatCountAtom,
   levelAtom,
-  seatInfoAtom,
-  themeSiteAtom
+  seatInfoAtom
 } from "../../store/atom";
 import { useAtomValue } from "jotai";
 import { useEffect, useState } from "react";
-import { useNavigate } from "react-router-dom";
 
 const Container = styled.div`
   border: 2px solid var(--fill-color);
   border-radius: 8px;
   width: 400px;
-  height: 457px;
   display: flex;
   flex-direction: column;
   justify-content: space-between;
+  padding: 60px 20px;
 `;
 
 const Title = styled.div`
   font-family: "pretendardB";
   margin-bottom: 20px;
-  margin: 20px 20px 0 20px;
 `;
 
 const InfoContainer = styled.div`
   display: flex;
   flex-direction: column;
-  margin: 20px 20px 0 20px;
 `;
 const InfoItem = styled.div`
   display: flex;
@@ -48,44 +42,26 @@ const InfoText = styled.div`
   font-size: 16px;
 `;
 const TotalAmount = styled.div`
-  margin: 0 20px 0 20px;
   display: flex;
   justify-content: space-between;
   border-top: 2px solid var(--fill-color);
+  padding: 20px 0;
 `;
 
 const AmountTitle = styled.div`
-  margin-top: 20px;
   font-family: pretendardB;
 `;
 const AmountContent = styled.div`
   font-family: pretendardB;
   font-size: 28px;
-  margin-top: 20px;
 `;
-const ButtonContainer = styled.div`
-  display: flex;
-  justify-content: space-around;
-`;
-const PaddingContainer = styled.div`
-  padding: 6px;
-`;
-const NextAnimation = styled(Animation)`
-  padding: 3px;
-`;
-const MyBookingInfo = ({
-  option,
-  step3Stage,
-  addStage,
-  isValidate,
-  setErrorArray
-}) => {
+
+const MyBookingInfo = ({ option }) => {
   const allowedSeat = useAtomValue(allowedSeatAtom);
   const seatCount = useAtomValue(seatCountAtom);
   const seatInfo = useAtomValue(seatInfoAtom);
   const level = useAtomValue(levelAtom);
-  const [buttonText, setButtonText] = useState("다음 단계");
-  const [focus, setFocus] = useState(false);
+
   const Info = [
     // 공연 날짜 및 시간
     { title: "일시", content: seatInfo.date },
@@ -98,53 +74,13 @@ const MyBookingInfo = ({
     { title: "배송비", price: `${option === "배송" ? 3000 : 0}` },
     { title: "쿠폰할인", price: 0 }
   ];
-  const nav = useNavigate();
 
-  const handleButtonClick = () => {
-    // 좌석 매수가 0일 경우 경고창 출력
-    if (seatCount === 0) {
-      alert("좌석을 선택해주세요.");
-      return;
-    }
-    // 매수가 1 이상이고 1단계 (티켓매수 선택 및 가격 확인)일 경우 결제하기로 변경
-    if (seatCount > 0 && step3Stage == 1) {
-      //2단계로 수정
-      setButtonText("결제하기");
-      addStage();
-      return;
-    }
-    // 버튼이 결제하기일 경우 step4-1로 이동
-    if (step3Stage == 2) {
-      //티켓수령방법 + 생년월일을 작성 검사 로직
-      if (!isValidate.includes("method")) {
-        setErrorArray(() => "method");
-        alert("티켓 수령 방법을 선택해 주세요");
-        return;
-      }
-      if (level === "high" && !isValidate.includes("birth")) {
-        setErrorArray(() => ["birth"]);
-        alert("생년월일을 정확하게 작성해 주세요");
-        return;
-      } else {
-        setErrorArray(() => []);
-        // 연습모드 라우팅
-        nav("../step4-1");
-      }
-    }
-  };
   const totalAmount = Info.reduce((acc, currentValue) => {
     if (currentValue.price !== undefined) {
       return acc + Number(currentValue.price);
     }
     return acc;
   }, 0);
-
-  // 애니메이션 등장 조절
-  useEffect(() => {
-    if (seatCount > 0 && level === "low") {
-      setFocus(true);
-    }
-  }, [seatCount]);
 
   return (
     <Container>
@@ -163,15 +99,6 @@ const MyBookingInfo = ({
         <AmountTitle>총 결제금액</AmountTitle>
         <AmountContent>{totalAmount}원</AmountContent>
       </TotalAmount>
-      <ButtonContainer>
-        <PaddingContainer>
-          <Button text="이전 단계" type="prev"></Button>
-        </PaddingContainer>
-
-        <NextAnimation $focus={focus}>
-          <Button text={buttonText} onClick={handleButtonClick}></Button>
-        </NextAnimation>
-      </ButtonContainer>
     </Container>
   );
 };

--- a/src/components/myBookingInfo/MyBookingInfoContainer.js
+++ b/src/components/myBookingInfo/MyBookingInfoContainer.js
@@ -1,0 +1,10 @@
+import styled from "styled-components";
+
+export const MyBookingInfoContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  padding: 10px 20px;
+  border: 2px solid var(--fill-color);
+  border-radius: 8px;
+`;

--- a/src/components/myBookingInfo/PrevNextButton.jsx
+++ b/src/components/myBookingInfo/PrevNextButton.jsx
@@ -1,0 +1,36 @@
+import styled from "styled-components";
+import AnimationArea from "../Animation";
+import { useAtomValue } from "jotai";
+import { levelAtom } from "../../store/atom";
+import Button from "../button/Button";
+
+const ButtonContainer = styled.div`
+  display: flex;
+  justify-content: space-around;
+`;
+const PaddingContainer = styled.div`
+  padding: 6px;
+`;
+const NextAnimation = styled(AnimationArea)`
+  padding: 3px;
+`;
+
+const PrevNextButton = ({ prevButtonOnClick, nextButtonOnClick }) => {
+  const level = useAtomValue(levelAtom);
+
+  return (
+    <ButtonContainer>
+      <PaddingContainer>
+        <Button
+          text="이전 단계"
+          onClick={prevButtonOnClick}
+          type="prev"
+        ></Button>
+      </PaddingContainer>
+      <NextAnimation $focus={level === "low"}>
+        <Button text="다음 단계" onClick={nextButtonOnClick}></Button>
+      </NextAnimation>
+    </ButtonContainer>
+  );
+};
+export default PrevNextButton;

--- a/src/components/seatInfo/SeatInfo.jsx
+++ b/src/components/seatInfo/SeatInfo.jsx
@@ -59,13 +59,7 @@ const SeatInfo = () => {
 
   const handleButtonClick = () => {
     if (isSeatSelected) {
-      // 연습모드 라우팅
-      if (themeSite === "practice") {
-        nav("/progress/step3-1");
-      } else {
-        // 실전모드 라우팅
-        nav(`/challenge/${themeSite}/step3-1`);
-      }
+      nav("../step3/step4");
     } else {
       alert("좌석을 선택해주세요.");
     }

--- a/src/components/timer/Timer.jsx
+++ b/src/components/timer/Timer.jsx
@@ -59,7 +59,7 @@ const Timer = ({ type, second }) => {
     }
 
     // 경로에 따라 타이머 멈춤 또는 재개
-    if (path === "/progress/step5") {
+    if (path.endsWith("step5") || path.endsWith("outro")) {
       //step5 -> 예매 성공일 경우 타이머 멈춤
       clearInterval(countdownRef.current);
     } else if (path.includes("step0")) {

--- a/src/hooks/useBookingValidate.js
+++ b/src/hooks/useBookingValidate.js
@@ -1,0 +1,44 @@
+import { useAtomValue } from "jotai";
+import { useNavigate } from "react-router-dom";
+import { levelAtom, seatCountAtom } from "../store/atom";
+
+export const useBookingValidate = (
+  addStage,
+  step3Stage,
+  isValidate,
+  setErrorArray,
+  location
+) => {
+  const seatCount = useAtomValue(seatCountAtom);
+  const level = useAtomValue(levelAtom);
+
+  const nav = useNavigate();
+  const handleButtonClick = () => {
+    // 좌석 매수가 0일 경우 경고창 출력
+    if (seatCount === 0) {
+      alert("좌석을 선택해주세요.");
+      return;
+    }
+    addStage(2);
+    console.log(step3Stage);
+    // 버튼이 결제하기일 경우 step4-1로 이동
+    if (step3Stage == 2) {
+      //티켓수령방법 + 생년월일을 작성 검사 로직
+      if (!isValidate.includes("method")) {
+        setErrorArray(() => ["method"]);
+        alert("티켓 수령 방법을 선택해 주세요");
+        return;
+      }
+      if (level === "high" && !isValidate.includes("birth")) {
+        setErrorArray(() => ["birth"]);
+        alert("생년월일을 정확하게 작성해 주세요");
+        return;
+      } else {
+        setErrorArray(() => []);
+        //라우팅
+        nav(location);
+      }
+    }
+  };
+  return handleButtonClick;
+};

--- a/src/hooks/useBookingValidate.js
+++ b/src/hooks/useBookingValidate.js
@@ -20,7 +20,7 @@ export const useBookingValidate = (
       return;
     }
     addStage(2);
-    console.log(step3Stage);
+    console.log(seatCount, step3Stage);
     // 버튼이 결제하기일 경우 step4-1로 이동
     if (step3Stage == 2) {
       //티켓수령방법 + 생년월일을 작성 검사 로직
@@ -40,5 +40,6 @@ export const useBookingValidate = (
       }
     }
   };
-  return handleButtonClick;
+
+  return { handleButtonClick };
 };

--- a/src/hooks/usePaymentValidate.js
+++ b/src/hooks/usePaymentValidate.js
@@ -1,0 +1,31 @@
+import { useState } from "react";
+import { useNavigate } from "react-router-dom";
+
+export const usePaymentValidate = ({ correctList }) => {
+  //step5 검사로직
+  const [hasPayFormError, setHasPayFormError] = useState();
+  const [cardTypesError, setCardTypesError] = useState();
+  //nav
+  const nav = useNavigate();
+
+  const handlePayment = () => {
+    console.log(correctList);
+
+    if (!correctList.DetailPayForm) {
+      setHasPayFormError(true);
+      alert("올바른 결제 수단을 선택해 주세요");
+      return;
+    }
+    if (!correctList.CardTypes) {
+      setHasPayFormError(false);
+      setCardTypesError(true);
+      alert("올바른 카드를 선택해 주세요");
+    } else {
+      nav("../step4-2");
+
+      setStepTextNumber((prev) => prev + 1);
+      setHelpTextNumber((prev) => prev + 1);
+    }
+  };
+  return { handlePayment, hasPayFormError, cardTypesError };
+};

--- a/src/index.css
+++ b/src/index.css
@@ -27,6 +27,7 @@
   --point-hover-color2: #efb316;
 
   /*gray scale*/
+  --dimmed-color: #f2f2f2;
   --fill-color: #cccccc;
   --text-color: #666666;
   --text-color2: #333333;

--- a/src/pages/Layout.jsx
+++ b/src/pages/Layout.jsx
@@ -18,14 +18,16 @@ const Layout = () => {
   const path = useLocation().pathname;
 
   useEffect(() => {
-    if (path === "/" || path.endsWith("step5")) {
-      resetAtom();
-    }
+    // if (path === "/" || path.endsWith("step5") || path.endsWith("record")) {
+    //   resetAtom();
+    // }
     if (!path.includes("challenge")) {
       if (themeSite !== "practice") {
         setThemeSite("practice");
       }
     }
+    // if (path === path.endsWith("outro")) {
+    // }
   }, [path]);
 
   return (

--- a/src/pages/ProgressContents.jsx
+++ b/src/pages/ProgressContents.jsx
@@ -108,7 +108,7 @@ const ProgressContents = ({ text }) => {
         <Timer type={"minute"} second={1800} />
       )}
       {themeSite !== "practice" && <Timer type={"minute"} second={900} />}
-      <TextBox>{stepText}</TextBox>
+      {!path.includes("challenge") && <TextBox>{stepText}</TextBox>}
       <ContentsBox>
         {/*도움말 버튼 */}
         {showHelpButton && (

--- a/src/pages/challengeMode/components/PosterSection.jsx
+++ b/src/pages/challengeMode/components/PosterSection.jsx
@@ -1,0 +1,110 @@
+import React from "react";
+import styled from "styled-components";
+import Poster from "../../../components/poster/Poster";
+import { useAtom } from "jotai";
+import { postersAtom, levelAtom } from "../../../store/atom";
+import { formatDateRange } from "../../../util/date";
+
+// 전체 요소를 담는 컨테이너
+const PosterContainer = styled.div`
+  display: flex;
+  justify-content: flex-start;
+  align-items: flex-start;
+  flex-direction: row;
+  flex-shrink: 0;
+`;
+
+// 포스터 이미지만 담는 섹션
+const LeftSection = styled.div`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  margin-right: 20px;
+`;
+
+// 타이틀과 공연 정보를 담는 섹션
+const RightSection = styled.div`
+  display: flex;
+  flex-direction: column;
+  justify-content: flex-start;
+  align-items: flex-start;
+`;
+
+// 공연 제목
+const PosterTitle = styled.h2`
+  font-family: "pretendardB";
+  font-size: 24px;
+  margin-bottom: 20px;
+  align-self: flex-start;
+`;
+
+// 테이블 스타일
+const InfoTable = styled.table`
+  width: 100%;
+  border-collapse: collapse;
+  font-family: "pretendardR";
+  font-size: 16px;
+  padding: 4px 8px;
+  color: var(--text-color);
+`;
+
+const InfoRow = styled.tr``;
+
+const InfoLabel = styled.td`
+  padding: 8px;
+  font-weight: bold;
+`;
+
+const InfoValue = styled.td`
+  padding: 8px;
+`;
+
+const PosterSection = ({ id }) => {
+  const [posters] = useAtom(postersAtom);
+  const [level] = useAtom(levelAtom);
+  const poster = posters[id];
+
+  return (
+    <PosterContainer>
+      <LeftSection>
+        <Poster id={id} />
+      </LeftSection>
+      <RightSection>
+        <PosterTitle>{poster.title_ko}</PosterTitle>
+        <InfoTable>
+          <tbody>
+            <InfoRow>
+              <InfoLabel>장소</InfoLabel>
+              <InfoValue>{poster.venue}</InfoValue>
+            </InfoRow>
+            <InfoRow>
+              <InfoLabel>공연기간</InfoLabel>
+              <InfoValue>{formatDateRange(poster.date)}</InfoValue>
+            </InfoRow>
+            <InfoRow>
+              <InfoLabel>관람연령</InfoLabel>
+              <InfoValue>{poster.age}</InfoValue>
+            </InfoRow>
+            <InfoRow>
+              <InfoLabel>가격</InfoLabel>
+              <InfoValue>
+                <table>
+                  <tbody>
+                    {Object.entries(poster.price).map(([seatType, price]) => (
+                      <InfoRow key={seatType}>
+                        <InfoLabel>{seatType}</InfoLabel>
+                        <InfoValue>{price}</InfoValue>
+                      </InfoRow>
+                    ))}
+                  </tbody>
+                </table>
+              </InfoValue>
+            </InfoRow>
+          </tbody>
+        </InfoTable>
+      </RightSection>
+    </PosterContainer>
+  );
+};
+
+export default PosterSection;

--- a/src/pages/challengeMode/components/payMethod/PayMethodChallenge.jsx
+++ b/src/pages/challengeMode/components/payMethod/PayMethodChallenge.jsx
@@ -1,0 +1,33 @@
+import styled from "styled-components";
+import { FormWrap } from "../../../../components/forms/FormStyle";
+import PayMethodForm from "../../../../components/forms/pay/PayMethodForm";
+import Input from "../../../../components/input/Input";
+import { SubTtitle } from "../../../practiceMode/step4/SelectPayMethod";
+
+export const SubTitleChallenge = styled(SubTtitle)`
+  margin-bottom: 20px;
+`;
+
+const PayMethodChallenge = () => {
+  return (
+    <FormWrap>
+      <SubTitleChallenge>결제 수단</SubTitleChallenge>
+      <PayMethodForm $focus={false} />
+      <Input name="PayMethodForm" type="radio" text="KB Pay" />
+      <Input name="PayMethodForm" type="radio" text="NOL 포인트" />
+      <Input name="PayMethodForm" type="radio" text="공연예매권" />
+      <Input
+        name="PayMethodForm"
+        type="radio"
+        text="I-Point 사용 (사용가능: 0p)"
+      />
+      <Input
+        name="PayMethodForm"
+        type="radio"
+        text="청년문화예술패스 포인트 사용 (사용가능: 0p)"
+      />
+    </FormWrap>
+  );
+};
+
+export default PayMethodChallenge;

--- a/src/pages/challengeMode/components/payMethod/UsablePoint.jsx
+++ b/src/pages/challengeMode/components/payMethod/UsablePoint.jsx
@@ -1,0 +1,35 @@
+import styled from "styled-components";
+
+const Title = styled.span`
+  color: var(--point-color);
+  font-size: 16px;
+`;
+
+const UsablePointCont = styled.span`
+  font-family: "pretendardM";
+  font-size: 14px;
+  color: var(--text-color);
+`;
+
+const Wrap = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+  background-color: var(--dimmed-color);
+  padding: 20px;
+  border-top: 1px solid var(--fill-color);
+`;
+
+const UsablePoint = () => {
+  return (
+    <Wrap>
+      <Title>사용 가능한 포인트</Title>
+      <UsablePointCont>마이 신한 포인트 (1점 이상)</UsablePointCont>
+      <UsablePointCont>씨티 포인트 (1점 이상)</UsablePointCont>
+      <UsablePointCont>삼성 보너스 포인트 (1p 이상)</UsablePointCont>
+      <UsablePointCont>외환 YES 포인트 (5천 p 이상)</UsablePointCont>
+    </Wrap>
+  );
+};
+
+export default UsablePoint;

--- a/src/pages/challengeMode/interpark/step1/PosterInterpark.jsx
+++ b/src/pages/challengeMode/interpark/step1/PosterInterpark.jsx
@@ -8,10 +8,9 @@ import { formatDateRange } from "../../../../util/date";
 // 전체 요소를 담는 컨테이너
 const PosterContainer = styled.div`
   display: flex;
-  justify-content: flex-start; /* 좌측 정렬 */
-  align-items: flex-start; /* 상단 정렬 */
+  justify-content: flex-start;
+  align-items: flex-start;
   flex-direction: row;
-
   flex-shrink: 0;
 `;
 

--- a/src/pages/challengeMode/interpark/step1/SelectRoundInterpark.jsx
+++ b/src/pages/challengeMode/interpark/step1/SelectRoundInterpark.jsx
@@ -7,8 +7,6 @@ import { useAtom } from "jotai";
 import {
   themeSiteAtom,
   selectedPosterAtom,
-  levelAtom,
-  progressAtom,
   postersAtom
 } from "../../../../store/atom";
 import { useNavigate } from "react-router-dom";
@@ -16,8 +14,8 @@ import formatTime from "../../../../util/time";
 
 const Container = styled.div`
   display: flex;
-  justify-content: space-between; /* 좌우로 공간 배분 */
-  align-items: flex-start; /* 상단 정렬 */
+  justify-content: space-between;
+  align-items: flex-start;
   padding: 20px 50px;
   width: 100%;
 `;
@@ -25,16 +23,16 @@ const Container = styled.div`
 const LeftSection = styled.div`
   display: flex;
   flex-direction: column;
-  justify-content: flex-start; /* 콘텐츠 상단 정렬 */
+  justify-content: flex-start;
   align-items: center;
 `;
 
 const RightSection = styled.div`
   display: flex;
   flex-direction: column;
-  justify-content: flex-start; /* 콘텐츠 상단 정렬 */
+  justify-content: flex-start;
   align-items: flex-start;
-  padding-left: 20px; /* 좌측 여백 추가 */
+  padding-left: 20px;
 `;
 
 const BoxWrapper = styled.div`
@@ -47,14 +45,12 @@ const BoxWrapper = styled.div`
 const RoundWrapper = styled.div`
   display: flex;
   flex-direction: column;
-  gap: 10px; /* 버튼 사이의 간격 추가 */
+  gap: 10px;
   width: 100%;
   padding-left: 20px;
 `;
 
 const SelectRoundInterpark = () => {
-  const [, setLevel] = useAtom(levelAtom);
-  const [, setProgress] = useAtom(progressAtom);
   const [selectedPoster] = useAtom(selectedPosterAtom);
   const [posters] = useAtom(postersAtom);
   const [posterId, setPosterId] = useState(0);
@@ -66,11 +62,9 @@ const SelectRoundInterpark = () => {
   const [, setThemeSite] = useAtom(themeSiteAtom);
 
   useEffect(() => {
-    setProgress(1);
     setThemeSite("interpark");
-    setLevel("high");
     setPosterId(0);
-  }, [setLevel, setProgress, selectedPoster, setThemeSite]);
+  }, [setThemeSite]);
 
   const poster = posters[posterId];
   const posterDates = poster ? poster.date : [];

--- a/src/pages/challengeMode/interpark/step3/SelectPriceInterpark.jsx
+++ b/src/pages/challengeMode/interpark/step3/SelectPriceInterpark.jsx
@@ -3,25 +3,55 @@ import styled from "styled-components";
 import MyBookingInfo from "../../../../components/myBookingInfo/MyBookingInfo";
 import SeatCount from "../../../../components/SeatCount";
 import TicketMethod from "../../../../components/forms/ticket/TicketMethod";
-import { useSetAtom } from "jotai";
-import { progressAtom } from "../../../../store/atom";
+import { useAtomValue, useSetAtom } from "jotai";
+import { levelAtom, progressAtom, seatCountAtom } from "../../../../store/atom";
+import Button from "../../../../components/button/Button";
+import Animation from "../../../../components/Animation";
+import { useBookingValidate } from "../../../../hooks/useBookingValidate";
+import { useNavigate } from "react-router-dom";
 
 const Wrap = styled.div`
   display: flex;
   gap: 20px;
 `;
-
+const MyBookingInfoContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+`;
+const ButtonContainer = styled.div`
+  display: flex;
+  justify-content: space-around;
+`;
+const PaddingContainer = styled.div`
+  padding: 6px;
+`;
+const NextAnimation = styled(Animation)`
+  padding: 3px;
+`;
 const SelectPriceInterpark = () => {
+  const level = useAtomValue(levelAtom);
+  const nav = useNavigate();
+
   //현장수령 or 배송
   const [option, setOption] = useState("현장수령");
   //step4 단계에 대한 정보
   const [step3Stage, setStep3Stage] = useState(1);
-  const addStage = () => setStep3Stage((prev) => prev + 1);
+  const addStage = (num) => setStep3Stage(num);
   const setProgress = useSetAtom(progressAtom);
   useEffect(() => setProgress(3));
-  // 폼 검사 로직
+  // 폼 검사 로직용
   const [isValidate, setIsValidate] = useState([]);
   const [errorArray, setErrorArray] = useState([]); //css 변경용
+  //검사후 이동할 위치
+  const location = "../step4-1";
+  //검사로직 (티켓가격 + 예매자 정보 확인용)
+  const handleButtonClick = useBookingValidate(
+    addStage,
+    step3Stage,
+    isValidate,
+    setErrorArray,
+    location
+  );
 
   return (
     <Wrap>
@@ -35,13 +65,22 @@ const SelectPriceInterpark = () => {
           errorArray={errorArray}
         />
       )}
-      <MyBookingInfo
-        step3Stage={step3Stage}
-        addStage={addStage}
-        option={option}
-        isValidate={isValidate}
-        setErrorArray={setErrorArray}
-      />
+      {/*내 예매정보 + 버튼 */}
+      <MyBookingInfoContainer>
+        <MyBookingInfo option={option} />
+        <ButtonContainer>
+          <PaddingContainer>
+            <Button
+              text="이전 단계"
+              onClick={() => setStep3Stage(1)}
+              type="prev"
+            ></Button>
+          </PaddingContainer>
+          <NextAnimation $focus={level === "low"}>
+            <Button text="다음 단계" onClick={handleButtonClick}></Button>
+          </NextAnimation>
+        </ButtonContainer>
+      </MyBookingInfoContainer>
     </Wrap>
   );
 };

--- a/src/pages/challengeMode/interpark/step3/SelectPriceInterpark.jsx
+++ b/src/pages/challengeMode/interpark/step3/SelectPriceInterpark.jsx
@@ -3,35 +3,18 @@ import styled from "styled-components";
 import MyBookingInfo from "../../../../components/myBookingInfo/MyBookingInfo";
 import SeatCount from "../../../../components/SeatCount";
 import TicketMethod from "../../../../components/forms/ticket/TicketMethod";
-import { useAtomValue, useSetAtom } from "jotai";
-import { levelAtom, progressAtom, seatCountAtom } from "../../../../store/atom";
-import Button from "../../../../components/button/Button";
-import Animation from "../../../../components/Animation";
+import { useSetAtom } from "jotai";
+import { progressAtom } from "../../../../store/atom";
 import { useBookingValidate } from "../../../../hooks/useBookingValidate";
-import { useNavigate } from "react-router-dom";
+import PrevNextButton from "../../../../components/myBookingInfo/PrevNextButton";
+import { MyBookingInfoContainer } from "../../../../components/myBookingInfo/MyBookingInfoContainer";
 
 const Wrap = styled.div`
   display: flex;
-  gap: 20px;
+  gap: 15px;
 `;
-const MyBookingInfoContainer = styled.div`
-  display: flex;
-  flex-direction: column;
-`;
-const ButtonContainer = styled.div`
-  display: flex;
-  justify-content: space-around;
-`;
-const PaddingContainer = styled.div`
-  padding: 6px;
-`;
-const NextAnimation = styled(Animation)`
-  padding: 3px;
-`;
-const SelectPriceInterpark = () => {
-  const level = useAtomValue(levelAtom);
-  const nav = useNavigate();
 
+const SelectPriceInterpark = () => {
   //현장수령 or 배송
   const [option, setOption] = useState("현장수령");
   //step4 단계에 대한 정보
@@ -44,8 +27,8 @@ const SelectPriceInterpark = () => {
   const [errorArray, setErrorArray] = useState([]); //css 변경용
   //검사후 이동할 위치
   const location = "../step4-1";
-  //검사로직 (티켓가격 + 예매자 정보 확인용)
-  const handleButtonClick = useBookingValidate(
+  // 버튼에 넘겨줄 검사로직 (티켓가격 + 예매자 정보 확인용)
+  const { handleButtonClick } = useBookingValidate(
     addStage,
     step3Stage,
     isValidate,
@@ -68,18 +51,11 @@ const SelectPriceInterpark = () => {
       {/*내 예매정보 + 버튼 */}
       <MyBookingInfoContainer>
         <MyBookingInfo option={option} />
-        <ButtonContainer>
-          <PaddingContainer>
-            <Button
-              text="이전 단계"
-              onClick={() => setStep3Stage(1)}
-              type="prev"
-            ></Button>
-          </PaddingContainer>
-          <NextAnimation $focus={level === "low"}>
-            <Button text="다음 단계" onClick={handleButtonClick}></Button>
-          </NextAnimation>
-        </ButtonContainer>
+        {/*이전 버튼, 다음 버튼 클릭 시 작동할 것*/}
+        <PrevNextButton
+          prevButtonOnClick={() => addStage(1)}
+          nextButtonOnClick={handleButtonClick}
+        />
       </MyBookingInfoContainer>
     </Wrap>
   );

--- a/src/pages/challengeMode/interpark/step3/SelectPriceInterpark.jsx
+++ b/src/pages/challengeMode/interpark/step3/SelectPriceInterpark.jsx
@@ -26,7 +26,7 @@ const SelectPriceInterpark = () => {
   const [isValidate, setIsValidate] = useState([]);
   const [errorArray, setErrorArray] = useState([]); //css 변경용
   //검사후 이동할 위치
-  const location = "../step4-1";
+  const location = "../step5-1";
   // 버튼에 넘겨줄 검사로직 (티켓가격 + 예매자 정보 확인용)
   const { handleButtonClick } = useBookingValidate(
     addStage,

--- a/src/pages/challengeMode/interpark/step4/SelectPayMethodInterPark.jsx
+++ b/src/pages/challengeMode/interpark/step4/SelectPayMethodInterPark.jsx
@@ -1,0 +1,96 @@
+import styled from "styled-components";
+import DetailPayForm from "../../../../components/forms/pay/DetailPayForm";
+import PayMethodChallenge, {
+  SubTitleChallenge
+} from "../../components/payMethod/PayMethodChallenge";
+import { useAtomValue, useSetAtom } from "jotai";
+import { useEffect } from "react";
+import { selectedPosterAtom, themeSiteAtom } from "../../../../store/atom";
+import { FormWrap } from "../../../../components/forms/FormStyle";
+import UsablePoint from "../../components/payMethod/UsablePoint";
+import MyBookingInfo from "../../../../components/myBookingInfo/MyBookingInfo";
+import PosterInfo from "../../../../components/poster/PosterInfo";
+
+//결제 수단 + 결제 방식 + 내 예매 정보
+const PayMethodWrap = styled.div`
+  display: flex;
+  gap: 15px;
+`;
+
+//결제 방식
+const PayMethodContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 30px;
+`;
+
+const CardInfo = styled.div`
+  display: flex;
+  gap: 20px;
+  background-color: var(--dimmed-color);
+  padding: 10px;
+`;
+
+//무이자 할부 안내 버튼
+const FakeButton = styled.div`
+  background-color: var(--point-color);
+  color: #fff;
+  font-size: 14px;
+  width: 120px;
+  height: 20px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  border-radius: 4px;
+`;
+
+//현금영수증 발급 안내
+const Info = styled.span`
+  font-size: 16px;
+  font-family: "pretendardM";
+  margin-top: 50px;
+  width: 90%;
+  line-height: 20px;
+  color: var(--text-color2);
+`;
+const SelectPayMethodInterPark = () => {
+  //애니메이션 제거 임시, 라우팅 연결이 된 후 삭제 예정
+  const setThemeSite = useSetAtom(themeSiteAtom);
+  useEffect(() => {
+    setThemeSite("interpark");
+  });
+  //포스터 정보
+  const posterId = useAtomValue(selectedPosterAtom);
+  return (
+    <PayMethodWrap>
+      <PayMethodContainer>
+        {/*결제 수단 */}
+        <PayMethodChallenge $focus={false} />
+        {/*사용 가능한 포인트 */}
+        <UsablePoint />
+      </PayMethodContainer>
+
+      {/*결제 방식 */}
+      <FormWrap>
+        <SubTitleChallenge>결제 방식</SubTitleChallenge>
+        <CardInfo>
+          {">"} 신용카드 정보 <FakeButton>무이자 할부 안내</FakeButton>
+        </CardInfo>
+        <DetailPayForm />
+        <Info>
+          ※현금영수증 발급 안내
+          <br />
+          현금영수증은 PC에서만 발급 가능하며, "예매내역 상세" 및 "마이페이지{" "}
+          {">"} 증빙서류 {">"} 현금영수증 메뉴"에서 신청할 수 있습니다.
+        </Info>
+      </FormWrap>
+
+      {/*내 예매 정보 */}
+      <div>
+        <PosterInfo id={posterId} />
+        <MyBookingInfo />
+      </div>
+    </PayMethodWrap>
+  );
+};
+export default SelectPayMethodInterPark;

--- a/src/pages/challengeMode/interpark/step4/SelectPayMethodInterPark.jsx
+++ b/src/pages/challengeMode/interpark/step4/SelectPayMethodInterPark.jsx
@@ -10,6 +10,9 @@ import { FormWrap } from "../../../../components/forms/FormStyle";
 import UsablePoint from "../../components/payMethod/UsablePoint";
 import MyBookingInfo from "../../../../components/myBookingInfo/MyBookingInfo";
 import PosterInfo from "../../../../components/poster/PosterInfo";
+import { MyBookingInfoContainer } from "../../../../components/myBookingInfo/MyBookingInfoContainer";
+import PrevNextButton from "../../../../components/myBookingInfo/PrevNextButton";
+import { useNavigate } from "react-router-dom";
 
 //결제 수단 + 결제 방식 + 내 예매 정보
 const PayMethodWrap = styled.div`
@@ -37,7 +40,7 @@ const FakeButton = styled.div`
   color: #fff;
   font-size: 14px;
   width: 120px;
-  height: 20px;
+  height: 25px;
   display: flex;
   justify-content: center;
   align-items: center;
@@ -61,6 +64,8 @@ const SelectPayMethodInterPark = () => {
   });
   //포스터 정보
   const posterId = useAtomValue(selectedPosterAtom);
+  //nav
+  const nav = useNavigate();
   return (
     <PayMethodWrap>
       <PayMethodContainer>
@@ -87,7 +92,13 @@ const SelectPayMethodInterPark = () => {
       {/*내 예매 정보 */}
       <div>
         <PosterInfo id={posterId} />
-        <MyBookingInfo />
+        <MyBookingInfoContainer>
+          <MyBookingInfo />
+          <PrevNextButton
+            prevButtonOnClick={() => nav("../step3-1")}
+            nextButtonOnClick={() => nav("../step5")}
+          />
+        </MyBookingInfoContainer>
       </div>
     </PayMethodWrap>
   );

--- a/src/pages/challengeMode/interpark/step4/SelectPayMethodInterPark.jsx
+++ b/src/pages/challengeMode/interpark/step4/SelectPayMethodInterPark.jsx
@@ -90,8 +90,8 @@ const SelectPayMethodInterPark = () => {
         <MyBookingInfoContainer>
           <MyBookingInfo />
           <PrevNextButton
-            prevButtonOnClick={() => nav("../step3-1")}
-            nextButtonOnClick={() => nav("../step5")}
+            prevButtonOnClick={() => nav("../step3/step4")}
+            nextButtonOnClick={() => nav("../step5-2")}
           />
         </MyBookingInfoContainer>
       </div>

--- a/src/pages/challengeMode/interpark/step4/SelectPayMethodInterPark.jsx
+++ b/src/pages/challengeMode/interpark/step4/SelectPayMethodInterPark.jsx
@@ -57,11 +57,6 @@ const Info = styled.span`
   color: var(--text-color2);
 `;
 const SelectPayMethodInterPark = () => {
-  //애니메이션 제거 임시, 라우팅 연결이 된 후 삭제 예정
-  const setThemeSite = useSetAtom(themeSiteAtom);
-  useEffect(() => {
-    setThemeSite("interpark");
-  });
   //포스터 정보
   const posterId = useAtomValue(selectedPosterAtom);
   //nav

--- a/src/pages/challengeMode/interpark/step5/SelectPayMethodInterPark.jsx
+++ b/src/pages/challengeMode/interpark/step5/SelectPayMethodInterPark.jsx
@@ -69,7 +69,6 @@ const SelectPayMethodInterPark = () => {
         {/*사용 가능한 포인트 */}
         <UsablePoint />
       </PayMethodContainer>
-
       {/*결제 방식 */}
       <FormWrap>
         <SubTitleChallenge>결제 방식</SubTitleChallenge>

--- a/src/pages/challengeMode/intro/ChallangeIntro.jsx
+++ b/src/pages/challengeMode/intro/ChallangeIntro.jsx
@@ -19,9 +19,11 @@ const ChallangeIntro = () => {
   const navigate = useNavigate();
   const [progress, setProgress] = useAtom(progressAtom);
   const themeSite = useAtomValue(themeSiteAtom);
+  const setLevel = useSetAtom(levelAtom);
 
   useEffect(() => {
     setProgress(0);
+    setLevel("high");
   }, [setProgress]);
 
   const handleClick = () => {

--- a/src/pages/challengeMode/intro/ChallangeIntro.jsx
+++ b/src/pages/challengeMode/intro/ChallangeIntro.jsx
@@ -2,7 +2,7 @@ import React, { useEffect, useState } from "react";
 import styled from "styled-components";
 import { useNavigate } from "react-router-dom";
 import { useAtom, useAtomValue, useSetAtom } from "jotai";
-import { progressAtom, themeSiteAtom } from "../../../store/atom";
+import { levelAtom, progressAtom, themeSiteAtom } from "../../../store/atom";
 import Button from "../../../components/button/Button";
 import AnimationArea from "../../../components/Animation";
 import ChallangeIntroMessage from "./introMessage/ChallangeIntroMessage";

--- a/src/pages/challengeMode/melonticket/step1/SelectRoundMelonticket.jsx
+++ b/src/pages/challengeMode/melonticket/step1/SelectRoundMelonticket.jsx
@@ -1,0 +1,161 @@
+import React, { useEffect, useState } from "react";
+import PosterSection from "../../components/PosterSection";
+import SelectCalender from "../../../../components/calender/SelectCalender";
+import Button from "../../../../components/button/Button";
+import styled from "styled-components";
+import { useAtomValue, useSetAtom } from "jotai";
+import {
+  themeSiteAtom,
+  selectedPosterAtom,
+  postersAtom
+} from "../../../../store/atom";
+import { useNavigate } from "react-router-dom";
+import formatTime from "../../../../util/time";
+
+const Container = styled.div`
+  display: flex;
+  flex-direction: column;
+  justify-content: flex-start;
+  align-items: center;
+  padding: 0 20vh;
+  box-sizing: border-box;
+`;
+
+const UpperSection = styled.div`
+  width: 100%;
+  display: flex;
+  justify-content: flex-start;
+  align-items: center;
+  margin-bottom: 30px;
+`;
+
+const LowerSection = styled.div`
+  width: 100%;
+  display: flex;
+  flex-direction: row;
+  gap: 30px;
+  justify-content: flex-start;
+  align-items: flex-start;
+`;
+
+const BoxWrapper = styled.div`
+  width: auto;
+  border: 1px solid var(--fill-color);
+  padding: 20px;
+  border-radius: 8px;
+  gap: 10px;
+  display: flex;
+  flex-direction: row;
+`;
+
+const TitleText = styled.p`
+  font-size: 18px;
+  white-space: nowrap; // 글자 크기 고정
+  margin: 0;
+`;
+
+const ButtonSection = styled.div`
+  width: 100%;
+  display: flex;
+  padding-top: 20px;
+  justify-content: flex-end;
+`;
+
+const SelectRoundMelonticket = () => {
+  const selectedPoster = useAtomValue(selectedPosterAtom);
+  const posters = useAtomValue(postersAtom);
+  const [posterId, setPosterId] = useState(0);
+  const [dateSelected, setDateSelected] = useState(false);
+  const [roundSelected, setRoundSelected] = useState(false);
+  const [timesButtons, setTimesButtons] = useState([]);
+  const [correctRound, setCorrectRound] = useState(null);
+  const navigate = useNavigate();
+  const setThemeSite = useSetAtom(themeSiteAtom);
+
+  useEffect(() => {
+    setThemeSite("melonticket");
+    setPosterId(1);
+  }, [setThemeSite]);
+
+  const poster = posters[posterId];
+  const posterDates = poster?.date || [];
+  const posterTimes = poster?.time || {};
+
+  const handleDateSelect = (formattedDate) => {
+    const correctDate = posterDates[0];
+    if (formattedDate === correctDate) {
+      setDateSelected(true);
+      const timesArray = formatTime(posterTimes, formattedDate);
+      setTimesButtons(timesArray);
+      if (timesArray.length > 0) {
+        setCorrectRound(timesArray[0]);
+      }
+    } else {
+      alert("날짜를 다시 선택해주세요.");
+    }
+  };
+
+  const handleRoundClick = (time) => {
+    if (!dateSelected) {
+      alert("먼저 올바른 날짜를 선택해주세요.");
+      return;
+    }
+    if (time === correctRound) {
+      alert(`${time}으로 공연을 예매합니다.`);
+      setRoundSelected(true);
+    } else {
+      alert("회차를 다시 선택해주세요.");
+    }
+  };
+
+  const handleReserveClick = () => {
+    if (!roundSelected) {
+      alert("먼저 회차를 선택해주세요.");
+      return;
+    }
+    navigate("/challenge/melonticket/step2");
+  };
+
+  return (
+    <Container>
+      <UpperSection>
+        <PosterSection id={posterId} />
+      </UpperSection>
+      <LowerSection>
+        <BoxWrapper>
+          <TitleText>날짜 선택</TitleText>
+          <SelectCalender
+            onDateSelect={handleDateSelect}
+            initialDate={
+              posterDates.length > 0 ? new Date(posterDates[0]) : new Date()
+            }
+          />
+        </BoxWrapper>
+        <BoxWrapper>
+          <TitleText>회차 선택</TitleText>
+          {timesButtons.length > 0 ? (
+            timesButtons.map((time, index) => (
+              <Button
+                key={index}
+                text={`${index + 1}회 - ${time}`}
+                type="outline"
+                onClick={() => handleRoundClick(time)}
+              />
+            ))
+          ) : (
+            <Button
+              text="날짜 선택 후 확인"
+              type="outline"
+              onClick={() => alert("날짜를 먼저 선택해주세요.")}
+            />
+          )}
+        </BoxWrapper>
+      </LowerSection>
+      <ButtonSection>
+        <Button text="인증 후 예매하기" onClick={handleReserveClick} />
+      </ButtonSection>
+    </Container>
+  );
+};
+
+export default SelectRoundMelonticket;

--- a/src/pages/challengeMode/outro/Outro.jsx
+++ b/src/pages/challengeMode/outro/Outro.jsx
@@ -1,9 +1,14 @@
-import React, { useEffect } from "react";
 import styled from "styled-components";
 import Button from "../../../components/button/Button";
-import { useAtom, useSetAtom } from "jotai";
-import { progressAtom, themeSiteAtom } from "../../../store/atom";
 import { useNavigate } from "react-router-dom";
+import { useAtomValue } from "jotai";
+import {
+  userNameAtom,
+  themeSiteAtom,
+  minuteCountAtom
+} from "../../../store/atom";
+import saveUserData from "../../../apis/saveUserData";
+import resetAtom from "../../../util/resetAtom";
 
 const Step5Container = styled.div`
   display: flex;
@@ -41,29 +46,35 @@ const ButtonWrapper = styled.div`
 `;
 
 const Outro = () => {
-  const [, setProgress] = useAtom(progressAtom);
   const navigate = useNavigate();
-  const setThemeSite = useSetAtom(themeSiteAtom);
-
-  useEffect(() => {
-    setProgress(5);
-    setThemeSite("practice");
-  }, [setProgress]);
+  // 기록 저장에 필요한 atom 불러오기
+  const userName = useAtomValue(userNameAtom);
+  const themeSite = useAtomValue(themeSiteAtom);
+  const timeSpent = useAtomValue(minuteCountAtom);
 
   // 다시 도전하기(사이트 선택)
   const handlePracticeModeClick = () => {
+    resetAtom();
     navigate("/select-site");
   };
 
   // 기록 보기
   const handleChallengeModeClick = () => {
+    resetAtom();
     navigate("/record");
+  };
+
+  // 기록 저장하기
+  const handleSaveDataClick = () => {
+    saveUserData(userName, themeSite, timeSpent);
+    alert("기록을 저장했습니다.");
   };
 
   return (
     <Step5Container>
       <SuccessMessage>예매 성공!</SuccessMessage>
       {/* 클리어 시간 추가 필요*/}
+      <Button text="기록 저장하기" onClick={handleSaveDataClick} />
       <PracticeMessage>다시 도전하시겠습니까?</PracticeMessage>
       <ButtonWrapper>
         <Button text="다시 도전하기" onClick={handlePracticeModeClick} />

--- a/src/pages/challengeMode/outro/Outro.jsx
+++ b/src/pages/challengeMode/outro/Outro.jsx
@@ -1,0 +1,80 @@
+import React, { useEffect } from "react";
+import styled from "styled-components";
+import Button from "../../../components/button/Button";
+import { useAtom, useSetAtom } from "jotai";
+import { progressAtom, themeSiteAtom } from "../../../store/atom";
+import { useNavigate } from "react-router-dom";
+
+const Step5Container = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  height: 50vh;
+  text-align: center;
+`;
+
+const SuccessMessage = styled.h1`
+  color: var(--key-color);
+  font-family: "pretendardB";
+  font-size: 70px;
+  font-style: normal;
+  font-weight: 700;
+  line-height: normal;
+  letter-spacing: -3.5px;
+  margin-bottom: 20px;
+`;
+
+const PracticeMessage = styled.p`
+  color: var(--text-color);
+  font-family: "pretendardM";
+  font-size: 40px;
+  font-weight: 600;
+  letter-spacing: -2px;
+  margin-bottom: 40px;
+`;
+
+const ButtonWrapper = styled.div`
+  display: flex;
+  flex-direction: row;
+  gap: 20px;
+`;
+
+const Outro = () => {
+  const [, setProgress] = useAtom(progressAtom);
+  const navigate = useNavigate();
+  const setThemeSite = useSetAtom(themeSiteAtom);
+
+  useEffect(() => {
+    setProgress(5);
+    setThemeSite("practice");
+  }, [setProgress]);
+
+  // 다시 도전하기(사이트 선택)
+  const handlePracticeModeClick = () => {
+    navigate("/select-site");
+  };
+
+  // 기록 보기
+  const handleChallengeModeClick = () => {
+    navigate("/record");
+  };
+
+  return (
+    <Step5Container>
+      <SuccessMessage>예매 성공!</SuccessMessage>
+      {/* 클리어 시간 추가 필요*/}
+      <PracticeMessage>다시 도전하시겠습니까?</PracticeMessage>
+      <ButtonWrapper>
+        <Button text="다시 도전하기" onClick={handlePracticeModeClick} />
+        <Button
+          text="기록 보러가기"
+          type="outline"
+          onClick={handleChallengeModeClick}
+        />
+      </ButtonWrapper>
+    </Step5Container>
+  );
+};
+
+export default Outro;

--- a/src/pages/challengeMode/outro/Record.jsx
+++ b/src/pages/challengeMode/outro/Record.jsx
@@ -1,0 +1,73 @@
+import React, { useEffect, useState } from "react";
+import styled from "styled-components";
+import { collection, getDocs } from "firebase/firestore";
+import { db } from "../../../../firebase-config";
+
+const RecordContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  padding: 20px;
+`;
+
+const RecordTitle = styled.h2`
+  font-family: "pretendardB";
+  font-size: 36px;
+  color: var(--key-color);
+  padding: 20px;
+`;
+
+const RecordList = styled.ul`
+  list-style: none;
+`;
+
+const RecordItem = styled.li`
+  display: flex;
+  padding: 10px;
+  margin-bottom: 10px;
+  font-family: "pretendardR";
+  font-size: 24px;
+  color: var(--text-color);
+`;
+
+const Record = () => {
+  const [records, setRecords] = useState([]);
+
+  // 데이터베이스로부터 데이터 읽어오기
+  useEffect(() => {
+    const fetchRecords = async () => {
+      try {
+        const querySnapshot = await getDocs(collection(db, "users"));
+        const recordsArray = querySnapshot.docs.map((doc) => ({
+          userName: doc.id,
+          ...doc.data()
+        }));
+        // 남은 시간이 많은 순으로 정렬
+        recordsArray.sort((a, b) => b.timeSpent - a.timeSpent);
+        setRecords(recordsArray);
+      } catch (error) {
+        console.error("Error fetching datas: ", error);
+      }
+    };
+
+    fetchRecords();
+  }, []);
+
+  return (
+    <RecordContainer>
+      <RecordTitle>클리어 기록 보기</RecordTitle>
+      <RecordList>
+        {records.map((record, index) => (
+          <RecordItem key={index}>
+            {index + 1}. {record.userName} -{" "}
+            {String(Math.floor(record.timeSpent / 60)).padStart(2, "0")}:
+            {String(record.timeSpent % 60).padStart(2, "0")}
+          </RecordItem>
+        ))}
+      </RecordList>
+    </RecordContainer>
+  );
+};
+
+export default Record;

--- a/src/pages/challengeMode/selectSite/SelectSite.jsx
+++ b/src/pages/challengeMode/selectSite/SelectSite.jsx
@@ -38,6 +38,7 @@ const ButtonBox = styled.div`
 const SelectSite = () => {
   const navigate = useNavigate();
   const setThemeSite = useSetAtom(themeSiteAtom);
+  const setLevel = useSetAtom(levelAtom);
 
   const handleClick = (path, themeSite) => {
     setThemeSite(themeSite); // 해당 사이트의 테마로 변경

--- a/src/pages/challengeMode/selectSite/SelectSite.jsx
+++ b/src/pages/challengeMode/selectSite/SelectSite.jsx
@@ -42,6 +42,7 @@ const SelectSite = () => {
 
   const handleClick = (path, themeSite) => {
     setThemeSite(themeSite); // 해당 사이트의 테마로 변경
+    setLevel("high"); // 고급 난이도로 변경
     navigate(path);
   };
 

--- a/src/pages/challengeMode/selectSite/SelectSite.jsx
+++ b/src/pages/challengeMode/selectSite/SelectSite.jsx
@@ -38,7 +38,6 @@ const ButtonBox = styled.div`
 const SelectSite = () => {
   const navigate = useNavigate();
   const setThemeSite = useSetAtom(themeSiteAtom);
-  const setLevel = useSetAtom(levelAtom);
 
   const handleClick = (path, themeSite) => {
     setThemeSite(themeSite); // 해당 사이트의 테마로 변경

--- a/src/pages/challengeMode/ticketlink/step1/SelectRoundTicketlink.jsx
+++ b/src/pages/challengeMode/ticketlink/step1/SelectRoundTicketlink.jsx
@@ -1,0 +1,161 @@
+import React, { useEffect, useState } from "react";
+import PosterSection from "../../components/PosterSection";
+import SelectCalender from "../../../../components/calender/SelectCalender";
+import Button from "../../../../components/button/Button";
+import styled from "styled-components";
+import { useAtomValue, useSetAtom } from "jotai";
+import {
+  themeSiteAtom,
+  selectedPosterAtom,
+  postersAtom
+} from "../../../../store/atom";
+import { useNavigate } from "react-router-dom";
+import formatTime from "../../../../util/time";
+
+const Container = styled.div`
+  display: flex;
+  flex-direction: column;
+  justify-content: flex-start;
+  align-items: center;
+  padding: 0 20vh;
+  box-sizing: border-box;
+`;
+
+const UpperSection = styled.div`
+  width: 100%;
+  display: flex;
+  justify-content: flex-start;
+  align-items: center;
+  margin-bottom: 30px;
+`;
+
+const LowerSection = styled.div`
+  width: 100%;
+  display: flex;
+  flex-direction: row;
+  gap: 30px;
+  justify-content: flex-start;
+  align-items: flex-start;
+`;
+
+const BoxWrapper = styled.div`
+  width: auto;
+  border: 1px solid var(--fill-color);
+  padding: 20px;
+  border-radius: 8px;
+  gap: 10px;
+  display: flex;
+  flex-direction: row;
+`;
+
+const TitleText = styled.p`
+  font-size: 18px;
+  white-space: nowrap; // 글자 크기 고정
+  margin: 0;
+`;
+
+const ButtonSection = styled.div`
+  width: 100%;
+  display: flex;
+  padding-top: 20px;
+  justify-content: flex-end;
+`;
+
+const SelectRoundTicketlink = () => {
+  const selectedPoster = useAtomValue(selectedPosterAtom);
+  const posters = useAtomValue(postersAtom);
+  const [posterId, setPosterId] = useState(0);
+  const [dateSelected, setDateSelected] = useState(false);
+  const [roundSelected, setRoundSelected] = useState(false);
+  const [timesButtons, setTimesButtons] = useState([]);
+  const [correctRound, setCorrectRound] = useState(null);
+  const navigate = useNavigate();
+  const setThemeSite = useSetAtom(themeSiteAtom);
+
+  useEffect(() => {
+    setThemeSite("ticketlink");
+    setPosterId(2);
+  }, [setThemeSite]);
+
+  const poster = posters[posterId];
+  const posterDates = poster?.date || [];
+  const posterTimes = poster?.time || {};
+
+  const handleDateSelect = (formattedDate) => {
+    const correctDate = posterDates[0];
+    if (formattedDate === correctDate) {
+      setDateSelected(true);
+      const timesArray = formatTime(posterTimes, formattedDate);
+      setTimesButtons(timesArray);
+      if (timesArray.length > 0) {
+        setCorrectRound(timesArray[0]);
+      }
+    } else {
+      alert("날짜를 다시 선택해주세요.");
+    }
+  };
+
+  const handleRoundClick = (time) => {
+    if (!dateSelected) {
+      alert("먼저 올바른 날짜를 선택해주세요.");
+      return;
+    }
+    if (time === correctRound) {
+      alert(`${time}으로 공연을 예매합니다.`);
+      setRoundSelected(true);
+    } else {
+      alert("회차를 다시 선택해주세요.");
+    }
+  };
+
+  const handleReserveClick = () => {
+    if (!roundSelected) {
+      alert("먼저 회차를 선택해주세요.");
+      return;
+    }
+    navigate("/challenge/ticketlink/step2");
+  };
+
+  return (
+    <Container>
+      <UpperSection>
+        <PosterSection id={posterId} />
+      </UpperSection>
+      <LowerSection>
+        <BoxWrapper>
+          <TitleText>날짜 선택</TitleText>
+          <SelectCalender
+            onDateSelect={handleDateSelect}
+            initialDate={
+              posterDates.length > 0 ? new Date(posterDates[0]) : new Date()
+            }
+          />
+        </BoxWrapper>
+        <BoxWrapper>
+          <TitleText>회차 선택</TitleText>
+          {timesButtons.length > 0 ? (
+            timesButtons.map((time, index) => (
+              <Button
+                key={index}
+                text={`${index + 1}회 - ${time}`}
+                type="outline"
+                onClick={() => handleRoundClick(time)}
+              />
+            ))
+          ) : (
+            <Button
+              text="날짜 선택 후 확인"
+              type="outline"
+              onClick={() => alert("날짜를 먼저 선택해주세요.")}
+            />
+          )}
+        </BoxWrapper>
+      </LowerSection>
+      <ButtonSection>
+        <Button text="인증 후 예매하기" onClick={handleReserveClick} />
+      </ButtonSection>
+    </Container>
+  );
+};
+
+export default SelectRoundTicketlink;

--- a/src/pages/challengeMode/yes24/step1/SelectRoundYes24.jsx
+++ b/src/pages/challengeMode/yes24/step1/SelectRoundYes24.jsx
@@ -1,0 +1,161 @@
+import React, { useEffect, useState } from "react";
+import PosterSection from "../../components/PosterSection";
+import SelectCalender from "../../../../components/calender/SelectCalender";
+import Button from "../../../../components/button/Button";
+import styled from "styled-components";
+import { useAtomValue, useSetAtom } from "jotai";
+import {
+  themeSiteAtom,
+  selectedPosterAtom,
+  postersAtom
+} from "../../../../store/atom";
+import { useNavigate } from "react-router-dom";
+import formatTime from "../../../../util/time";
+
+const Container = styled.div`
+  display: flex;
+  flex-direction: column;
+  justify-content: flex-start;
+  align-items: center;
+  padding: 0 20vh;
+  box-sizing: border-box;
+`;
+
+const UpperSection = styled.div`
+  width: 100%;
+  display: flex;
+  justify-content: flex-start;
+  align-items: center;
+  margin-bottom: 30px;
+`;
+
+const LowerSection = styled.div`
+  width: 100%;
+  display: flex;
+  flex-direction: row;
+  gap: 30px;
+  justify-content: flex-start;
+  align-items: flex-start;
+`;
+
+const BoxWrapper = styled.div`
+  width: auto;
+  border: 1px solid var(--fill-color);
+  padding: 20px;
+  border-radius: 8px;
+  gap: 10px;
+  display: flex;
+  flex-direction: row;
+`;
+
+const TitleText = styled.p`
+  font-size: 18px;
+  white-space: nowrap; // 글자 크기 고정
+  margin: 0;
+`;
+
+const ButtonSection = styled.div`
+  width: 100%;
+  display: flex;
+  padding-top: 20px;
+  justify-content: flex-end;
+`;
+
+const SelectRoundYes24 = () => {
+  const selectedPoster = useAtomValue(selectedPosterAtom);
+  const posters = useAtomValue(postersAtom);
+  const [posterId, setPosterId] = useState(0);
+  const [dateSelected, setDateSelected] = useState(false);
+  const [roundSelected, setRoundSelected] = useState(false);
+  const [timesButtons, setTimesButtons] = useState([]);
+  const [correctRound, setCorrectRound] = useState(null);
+  const navigate = useNavigate();
+  const setThemeSite = useSetAtom(themeSiteAtom);
+
+  useEffect(() => {
+    setThemeSite("yes24");
+    setPosterId(3);
+  }, [setThemeSite]);
+
+  const poster = posters[posterId];
+  const posterDates = poster?.date || [];
+  const posterTimes = poster?.time || {};
+
+  const handleDateSelect = (formattedDate) => {
+    const correctDate = posterDates[0];
+    if (formattedDate === correctDate) {
+      setDateSelected(true);
+      const timesArray = formatTime(posterTimes, formattedDate);
+      setTimesButtons(timesArray);
+      if (timesArray.length > 0) {
+        setCorrectRound(timesArray[0]);
+      }
+    } else {
+      alert("날짜를 다시 선택해주세요.");
+    }
+  };
+
+  const handleRoundClick = (time) => {
+    if (!dateSelected) {
+      alert("먼저 올바른 날짜를 선택해주세요.");
+      return;
+    }
+    if (time === correctRound) {
+      alert(`${time}으로 공연을 예매합니다.`);
+      setRoundSelected(true);
+    } else {
+      alert("회차를 다시 선택해주세요.");
+    }
+  };
+
+  const handleReserveClick = () => {
+    if (!roundSelected) {
+      alert("먼저 회차를 선택해주세요.");
+      return;
+    }
+    navigate("/challenge/yes24/step2");
+  };
+
+  return (
+    <Container>
+      <UpperSection>
+        <PosterSection id={posterId} />
+      </UpperSection>
+      <LowerSection>
+        <BoxWrapper>
+          <TitleText>날짜 선택</TitleText>
+          <SelectCalender
+            onDateSelect={handleDateSelect}
+            initialDate={
+              posterDates.length > 0 ? new Date(posterDates[0]) : new Date()
+            }
+          />
+        </BoxWrapper>
+        <BoxWrapper>
+          <TitleText>회차 선택</TitleText>
+          {timesButtons.length > 0 ? (
+            timesButtons.map((time, index) => (
+              <Button
+                key={index}
+                text={`${index + 1}회 - ${time}`}
+                type="outline"
+                onClick={() => handleRoundClick(time)}
+              />
+            ))
+          ) : (
+            <Button
+              text="날짜 선택 후 확인"
+              type="outline"
+              onClick={() => alert("날짜를 먼저 선택해주세요.")}
+            />
+          )}
+        </BoxWrapper>
+      </LowerSection>
+      <ButtonSection>
+        <Button text="인증 후 예매하기" onClick={handleReserveClick} />
+      </ButtonSection>
+    </Container>
+  );
+};
+
+export default SelectRoundYes24;

--- a/src/pages/practiceMode/step3/SeatPriceCheck.jsx
+++ b/src/pages/practiceMode/step3/SeatPriceCheck.jsx
@@ -9,6 +9,9 @@ import {
   stepTextNumberAtom,
   helpTextNumberAtom
 } from "../../../store/atom";
+import { MyBookingInfoContainer } from "../../../components/myBookingInfo/MyBookingInfoContainer";
+import PrevNextButton from "../../../components/myBookingInfo/PrevNextButton";
+import { useBookingValidate } from "../../../hooks/useBookingValidate";
 
 const Wrap = styled.div`
   display: flex;
@@ -20,7 +23,7 @@ const SeatPriceCheck = () => {
   const [option, setOption] = useState("현장수령");
   //step4 단계에 대한 정보
   const [step3Stage, setStep3Stage] = useState(1);
-  const addStage = () => setStep3Stage((prev) => prev + 1);
+  const addStage = () => setStep3Stage(2);
   const setProgress = useSetAtom(progressAtom);
 
   const setStepTextNumber = useSetAtom(stepTextNumberAtom);
@@ -39,9 +42,19 @@ const SeatPriceCheck = () => {
     }
   }, [step3Stage]);
 
-  // 폼 검사 로직
+  // 폼 검사 로직용
   const [isValidate, setIsValidate] = useState([]);
   const [errorArray, setErrorArray] = useState([]); //css 변경용
+  //검사후 이동할 위치
+  const location = "../step4-1";
+  // 버튼에 넘겨줄 검사로직 (티켓가격 + 예매자 정보 확인용)
+  const handleButtonClick = useBookingValidate(
+    addStage,
+    step3Stage,
+    isValidate,
+    setErrorArray,
+    location
+  );
 
   return (
     <Wrap>
@@ -55,13 +68,19 @@ const SeatPriceCheck = () => {
           errorArray={errorArray}
         />
       )}
-      <MyBookingInfo
-        step3Stage={step3Stage}
-        addStage={addStage}
-        option={option}
-        isValidate={isValidate}
-        setErrorArray={setErrorArray}
-      />
+      <MyBookingInfoContainer>
+        <MyBookingInfo
+          step3Stage={step3Stage}
+          addStage={addStage}
+          option={option}
+          isValidate={isValidate}
+          setErrorArray={setErrorArray}
+        />
+        <PrevNextButton
+          prevButtonOnClick={() => addStage(1)}
+          nextButtonOnClick={handleButtonClick}
+        />
+      </MyBookingInfoContainer>
     </Wrap>
   );
 };

--- a/src/pages/practiceMode/step4/CardPay.jsx
+++ b/src/pages/practiceMode/step4/CardPay.jsx
@@ -3,15 +3,10 @@ import Card from "../../../components/card/Card";
 import CardForm from "../../../components/forms/CardForm";
 import { useForm } from "../../../hooks/useForm";
 import Button from "../../../components/button/Button";
-import { useAtomValue, useSetAtom, useAtom } from "jotai";
-import {
-  cardAnswerAtom,
-  stepTextNumberAtom,
-  themeSiteAtom
-} from "../../../store/atom";
+import { useAtomValue } from "jotai";
+import { cardAnswerAtom, themeSiteAtom } from "../../../store/atom";
 import { Step4Container } from "./SelectPayMethod";
 import { useNavigate } from "react-router-dom";
-import { useEffect, useState } from "react";
 
 const CardPayWrap = styled(Step4Container)`
   align-items: center;
@@ -47,7 +42,6 @@ const CardPay = () => {
       : 1
     : 0;
   const nav = useNavigate();
-  const themeSite = useAtomValue(themeSiteAtom);
 
   //검사로직
   const handleClick = () => {

--- a/src/pages/practiceMode/step4/CardPay.jsx
+++ b/src/pages/practiceMode/step4/CardPay.jsx
@@ -4,7 +4,11 @@ import CardForm from "../../../components/forms/CardForm";
 import { useForm } from "../../../hooks/useForm";
 import Button from "../../../components/button/Button";
 import { useAtomValue } from "jotai";
-import { cardAnswerAtom, themeSiteAtom } from "../../../store/atom";
+import {
+  cardAnswerAtom,
+  themeSiteAtom,
+  userNameAtom
+} from "../../../store/atom";
 import { Step4Container } from "./SelectPayMethod";
 import { useNavigate } from "react-router-dom";
 
@@ -42,13 +46,22 @@ const CardPay = () => {
       : 1
     : 0;
   const nav = useNavigate();
+  // 실전 모드 여부를 판단하기 위한 테마 정보
+  const themeSite = useAtomValue(themeSiteAtom);
+
+  //타임스탬프
+  const userName = useAtomValue(userNameAtom);
 
   //검사로직
   const handleClick = () => {
     if (!isAnswer) {
       alert("카드 정보를 정확하게 입력해 주세요");
     } else {
-      nav("../step5");
+      if (themeSite === "practice") {
+        nav("../step5");
+      } else {
+        nav("../outro");
+      }
     }
   };
   return (
@@ -61,7 +74,7 @@ const CardPay = () => {
         <CardForm focusNum={focusNum} handleChange={handleChange} />
       </CardFormContainer>
       {/*다음단계 버튼을 누르면 step5로 이동 */}
-      <Button text="다음 단계" onClick={handleClick} />
+      <Button text="결제 완료" onClick={handleClick} />
     </CardPayWrap>
   );
 };

--- a/src/pages/practiceMode/step4/SelectPayMethod.jsx
+++ b/src/pages/practiceMode/step4/SelectPayMethod.jsx
@@ -5,10 +5,9 @@ import DetailPayForm from "../../../components/forms/pay/DetailPayForm";
 import { useForm } from "../../../hooks/useForm";
 import Button from "../../../components/button/Button";
 import { useNavigate } from "react-router-dom";
-import { useSetAtom, useAtomValue } from "jotai";
+import { useSetAtom } from "jotai";
 import {
   progressAtom,
-  themeSiteAtom,
   stepTextNumberAtom,
   helpTextNumberAtom
 } from "../../../store/atom";
@@ -28,7 +27,7 @@ export const Step4Container = styled.div`
   gap: 20px;
   margin: 0 20px;
 `;
-const SubTtitle = styled.div`
+export const SubTtitle = styled.div`
   width: 447px;
   height: 37px;
   border-bottom: 1px solid var(--fill-color);
@@ -70,7 +69,6 @@ const SelectPayMethod = () => {
   //검사 로직
   const [hasPayFormError, setHasPayFormError] = useState(false);
   const [cardTypesError, setCardTypesError] = useState(false);
-  const themeSite = useAtomValue(themeSiteAtom);
   const nav = useNavigate();
 
   const handleClick = () => {

--- a/src/pages/practiceMode/step4/SelectPayMethod.jsx
+++ b/src/pages/practiceMode/step4/SelectPayMethod.jsx
@@ -4,13 +4,14 @@ import PayMethodForm from "../../../components/forms/pay/PayMethodForm";
 import DetailPayForm from "../../../components/forms/pay/DetailPayForm";
 import { useForm } from "../../../hooks/useForm";
 import Button from "../../../components/button/Button";
-import { useNavigate } from "react-router-dom";
 import { useSetAtom } from "jotai";
 import {
   progressAtom,
   stepTextNumberAtom,
   helpTextNumberAtom
 } from "../../../store/atom";
+import { useBookingValidate } from "../../../hooks/useBookingValidate";
+import { usePaymentValidate } from "../../../hooks/usePaymentValidate";
 
 const SelectPayWrap = styled.div`
   width: 80%;
@@ -47,7 +48,10 @@ const SelectPayMethod = () => {
   const { handleChange, correctList, isAnswer } = useForm(3);
   //'신용카드'를 정확히 골랐을 경우 '결제 수단 입력' 창 생성
   const isPayMethodCorrect = correctList["PayMethodForm"];
-
+  //검사로직
+  const { handlePayment, hasPayFormError, cardTypesError } = usePaymentValidate(
+    { correctList }
+  );
   const setStepTextNumber = useSetAtom(stepTextNumberAtom);
   const setHelpTextNumber = useSetAtom(helpTextNumberAtom);
 
@@ -65,29 +69,6 @@ const SelectPayMethod = () => {
       setHelpTextNumber((prev) => prev + 1);
     }
   }, [isPayMethodCorrect]);
-
-  //검사 로직
-  const [hasPayFormError, setHasPayFormError] = useState(false);
-  const [cardTypesError, setCardTypesError] = useState(false);
-  const nav = useNavigate();
-
-  const handleClick = () => {
-    if (!correctList.DetailPayForm) {
-      setHasPayFormError(true);
-      alert("올바른 결제 수단을 선택해 주세요");
-      return;
-    }
-    if (!correctList.CardTypes) {
-      setHasPayFormError(false);
-      setCardTypesError(true);
-      alert("올바른 카드를 선택해 주세요");
-    } else {
-      nav("../step4-2");
-
-      setStepTextNumber((prev) => prev + 1);
-      setHelpTextNumber((prev) => prev + 1);
-    }
-  };
 
   return (
     <SelectPayWrap>
@@ -113,7 +94,7 @@ const SelectPayMethod = () => {
             />
           </Step4Container>
           <BtnWrap>
-            <Button text="다음 단계" onClick={handleClick} />
+            <Button text="다음 단계" onClick={handlePayment} />
           </BtnWrap>
         </>
       )}

--- a/src/pages/practiceMode/step5/Step5.jsx
+++ b/src/pages/practiceMode/step5/Step5.jsx
@@ -4,7 +4,7 @@ import Button from "../../../components/button/Button";
 import { useAtom, useSetAtom } from "jotai";
 import { levelAtom, progressAtom, themeSiteAtom } from "../../../store/atom";
 import { useNavigate } from "react-router-dom";
-
+import resetAtom from "../../../util/resetAtom";
 const Step5Container = styled.div`
   display: flex;
   flex-direction: column;
@@ -54,11 +54,13 @@ const Step5 = () => {
 
   // 난이도 선택 창으로
   const handlePracticeModeClick = () => {
+    resetAtom();
     navigate("/select-level");
   };
 
   // 실전 모드 선택 창으로
   const handleChallengeModeClick = () => {
+    resetAtom();
     navigate("/select-site"); // 추후 path 수정 필요
   };
 

--- a/src/routes.jsx
+++ b/src/routes.jsx
@@ -14,6 +14,9 @@ import ChallangeIntro from "./pages/challengeMode/intro/ChallangeIntro";
 import SelectPerformance from "./pages/practiceMode/step1/SelectPerformance";
 import SelectRound from "./pages/practiceMode/step1/SelectRound";
 import SelectRoundInterpark from "./pages/challengeMode/interpark/step1/SelectRoundInterpark";
+import SelectRoundMelonticket from "./pages/challengeMode/melonticket/step1/SelectRoundMelonticket";
+import SelectRoundTicketlink from "./pages/challengeMode/ticketlink/step1/SelectRoundTicketlink";
+import SelectRoundYes24 from "./pages/challengeMode/yes24/step1/SelectRoundYes24";
 // step 2
 import SelectSeat from "./pages/practiceMode/step2/SelectSeat";
 import SelectSeatInterpark from "./pages/challengeMode/interpark/step2/SelectSeatInterpark";
@@ -133,6 +136,11 @@ const router = createBrowserRouter([
                 path: "step0",
                 element: <PrivateRoute element={<ChallangeIntro />} />,
                 lable: "인트로"
+              },
+              {
+                path: "step1",
+                element: <PrivateRoute element={<SelectRoundMelonticket />} />,
+                label: "날짜 및 회차 선택"
               }
             ]
           },
@@ -144,6 +152,11 @@ const router = createBrowserRouter([
                 path: "step0",
                 element: <PrivateRoute element={<ChallangeIntro />} />,
                 lable: "인트로"
+              },
+              {
+                path: "step1",
+                element: <PrivateRoute element={<SelectRoundTicketlink />} />,
+                label: "날짜 및 회차 선택"
               }
             ]
           },
@@ -155,6 +168,11 @@ const router = createBrowserRouter([
                 path: "step0",
                 element: <PrivateRoute element={<ChallangeIntro />} />,
                 lable: "인트로"
+              },
+              {
+                path: "step1",
+                element: <PrivateRoute element={<SelectRoundYes24 />} />,
+                label: "날짜 및 회차 선택"
               }
             ]
           }

--- a/src/routes.jsx
+++ b/src/routes.jsx
@@ -27,6 +27,7 @@ import CardPay from "./pages/practiceMode/step4/CardPay";
 // step 5
 import Step5 from "./pages/practiceMode/step5/Step5";
 import Outro from "./pages/challengeMode/outro/Outro";
+import Record from "./pages/challengeMode/outro/Record";
 
 const router = createBrowserRouter([
   {
@@ -37,6 +38,8 @@ const router = createBrowserRouter([
       { path: "select-mode", element: <SelectMode />, label: "모드 선택" },
       { path: "select-level", element: <SelectLevel />, label: "난이도 선택" },
       { path: "select-site", element: <SelectSite />, label: "사이트 선택" },
+      { path: "record", element: <Record />, label: "기록 보기" },
+
       {
         path: "progress",
         element: <ProgressContents />,
@@ -96,6 +99,7 @@ const router = createBrowserRouter([
                 element: <PrivateRoute element={<ChallangeIntro />} />,
                 label: "인트로"
               },
+              // 공연 선택 단계 추가 필요
               {
                 path: "step1",
                 element: <PrivateRoute element={<SelectRoundInterpark />} />,
@@ -104,27 +108,28 @@ const router = createBrowserRouter([
               {
                 path: "step2",
                 element: <PrivateRoute element={<SelectSeatInterpark />} />,
-                label: ""
+                label: "좌석 선택"
               },
               {
-                path: "step3-1",
+                path: "step3/step4",
                 element: <PrivateRoute element={<SelectPriceInterpark />} />,
-                label: "날짜 및 회차 선택"
+                label:
+                  "가격 할인 및 선택 / 배송 선택 / 주문자 확인 - 프로그래스 3,4"
               },
               {
-                path: "step4-1",
+                path: "step5-1",
                 element: (
                   <PrivateRoute element={<SelectPayMethodInterPark />} />
                 ),
-                label: "결제방식 / 수단 선택"
+                label: "결제방식 / 수단 선택 - 프로그래스 5"
               },
               {
-                path: "step5",
+                path: "step5-2",
                 element: <PrivateRoute element={<CardPay />} />,
                 label: "카드 결제창"
               },
               {
-                path: "step5-3",
+                path: "outro",
                 element: <PrivateRoute element={<Outro />} />,
                 label: "예매 성공"
               }

--- a/src/routes.jsx
+++ b/src/routes.jsx
@@ -22,7 +22,7 @@ import SeatPriceCheck from "./pages/practiceMode/step3/SeatPriceCheck";
 import SelectPriceInterpark from "./pages/challengeMode/interpark/step3/SelectPriceInterpark";
 // step 4
 import SelectPayMethod from "./pages/practiceMode/step4/SelectPayMethod";
-import SelectPayMethodInterPark from "./pages/challengeMode/interpark/step4/SelectPayMethodInterPark";
+import SelectPayMethodInterPark from "./pages/challengeMode/interpark/step5/SelectPayMethodInterPark";
 import CardPay from "./pages/practiceMode/step4/CardPay";
 // step 5
 import Step5 from "./pages/practiceMode/step5/Step5";

--- a/src/routes.jsx
+++ b/src/routes.jsx
@@ -21,8 +21,8 @@ import SelectSeatInterpark from "./pages/challengeMode/interpark/step2/SelectSea
 import SeatPriceCheck from "./pages/practiceMode/step3/SeatPriceCheck";
 import SelectPriceInterpark from "./pages/challengeMode/interpark/step3/SelectPriceInterpark";
 // step 4
-import SelectPayMethod from "./pages/practiceMode/step4/SelectPayMethod";
 import SelectPayMethodInterPark from "./pages/challengeMode/interpark/step5/SelectPayMethodInterPark";
+import SelectPayMethod from "./pages/practiceMode/step4/SelectPayMethod";
 import CardPay from "./pages/practiceMode/step4/CardPay";
 // step 5
 import Step5 from "./pages/practiceMode/step5/Step5";
@@ -110,19 +110,24 @@ const router = createBrowserRouter([
                 label: "날짜 및 회차 선택"
               },
               {
-                path: "step4-1",
+                path: "step4",
+                element: <PrivateRoute elemenet={<SeatPriceCheck />} />,
+                label: "배송선택/주소지 입력"
+              },
+              {
+                path: "step5-1",
                 element: (
                   <PrivateRoute element={<SelectPayMethodInterPark />} />
                 ),
                 label: "결제방식 / 수단 선택"
               },
               {
-                path: "step4-2",
+                path: "step5-2",
                 element: <PrivateRoute element={<CardPay />} />,
                 label: "카드 결제창"
               },
               {
-                path: "step5",
+                path: "step5-3",
                 element: <PrivateRoute element={<Step5 />} />,
                 label: "예매 성공"
               }

--- a/src/routes.jsx
+++ b/src/routes.jsx
@@ -82,6 +82,7 @@ const router = createBrowserRouter([
           }
         ]
       },
+      //실전모드
       {
         path: "challenge",
         children: [
@@ -110,12 +111,7 @@ const router = createBrowserRouter([
                 label: "날짜 및 회차 선택"
               },
               {
-                path: "step4",
-                element: <PrivateRoute elemenet={<SeatPriceCheck />} />,
-                label: "배송선택/주소지 입력"
-              },
-              {
-                path: "step5-1",
+                path: "step4-1",
                 element: (
                   <PrivateRoute element={<SelectPayMethodInterPark />} />
                 ),

--- a/src/routes.jsx
+++ b/src/routes.jsx
@@ -22,6 +22,7 @@ import SeatPriceCheck from "./pages/practiceMode/step3/SeatPriceCheck";
 import SelectPriceInterpark from "./pages/challengeMode/interpark/step3/SelectPriceInterpark";
 // step 4
 import SelectPayMethod from "./pages/practiceMode/step4/SelectPayMethod";
+import SelectPayMethodInterPark from "./pages/challengeMode/interpark/step4/SelectPayMethodInterPark";
 import CardPay from "./pages/practiceMode/step4/CardPay";
 // step 5
 import Step5 from "./pages/practiceMode/step5/Step5";
@@ -110,7 +111,9 @@ const router = createBrowserRouter([
               },
               {
                 path: "step4-1",
-                element: <PrivateRoute element={<SelectPayMethod />} />,
+                element: (
+                  <PrivateRoute element={<SelectPayMethodInterPark />} />
+                ),
                 label: "결제방식 / 수단 선택"
               },
               {

--- a/src/routes.jsx
+++ b/src/routes.jsx
@@ -21,7 +21,7 @@ import SelectSeatInterpark from "./pages/challengeMode/interpark/step2/SelectSea
 import SeatPriceCheck from "./pages/practiceMode/step3/SeatPriceCheck";
 import SelectPriceInterpark from "./pages/challengeMode/interpark/step3/SelectPriceInterpark";
 // step 4
-import SelectPayMethodInterPark from "./pages/challengeMode/interpark/step5/SelectPayMethodInterPark";
+import SelectPayMethodInterPark from "./pages/challengeMode/interpark/step4/SelectPayMethodInterPark";
 import SelectPayMethod from "./pages/practiceMode/step4/SelectPayMethod";
 import CardPay from "./pages/practiceMode/step4/CardPay";
 // step 5
@@ -118,7 +118,7 @@ const router = createBrowserRouter([
                 label: "결제방식 / 수단 선택"
               },
               {
-                path: "step5-2",
+                path: "step5",
                 element: <PrivateRoute element={<CardPay />} />,
                 label: "카드 결제창"
               },

--- a/src/routes.jsx
+++ b/src/routes.jsx
@@ -28,6 +28,9 @@ import SelectPayMethod from "./pages/practiceMode/step4/SelectPayMethod";
 import CardPay from "./pages/practiceMode/step4/CardPay";
 // step 5
 import Step5 from "./pages/practiceMode/step5/Step5";
+import Outro from "./pages/challengeMode/outro/Outro";
+// 기록 보기
+import Record from "./pages/challengeMode/outro/Record";
 
 const router = createBrowserRouter([
   {
@@ -38,6 +41,7 @@ const router = createBrowserRouter([
       { path: "select-mode", element: <SelectMode />, label: "모드 선택" },
       { path: "select-level", element: <SelectLevel />, label: "난이도 선택" },
       { path: "select-site", element: <SelectSite />, label: "사이트 선택" },
+      { path: "record", element: <Record />, label: "기록 보기" },
       {
         path: "progress",
         element: <ProgressContents />,
@@ -123,7 +127,7 @@ const router = createBrowserRouter([
               },
               {
                 path: "step5",
-                element: <PrivateRoute element={<Step5 />} />,
+                element: <PrivateRoute element={<Outro />} />,
                 label: "예매 성공"
               }
             ]
@@ -141,6 +145,11 @@ const router = createBrowserRouter([
                 path: "step1",
                 element: <PrivateRoute element={<SelectRoundMelonticket />} />,
                 label: "날짜 및 회차 선택"
+              },
+              {
+                path: "step5",
+                element: <PrivateRoute element={<Outro />} />,
+                label: "예매 성공"
               }
             ]
           },
@@ -157,6 +166,11 @@ const router = createBrowserRouter([
                 path: "step1",
                 element: <PrivateRoute element={<SelectRoundTicketlink />} />,
                 label: "날짜 및 회차 선택"
+              },
+              {
+                path: "step5",
+                element: <PrivateRoute element={<Outro />} />,
+                label: "예매 성공"
               }
             ]
           },
@@ -173,6 +187,11 @@ const router = createBrowserRouter([
                 path: "step1",
                 element: <PrivateRoute element={<SelectRoundYes24 />} />,
                 label: "날짜 및 회차 선택"
+              },
+              {
+                path: "step5",
+                element: <PrivateRoute element={<Outro />} />,
+                label: "예매 성공"
               }
             ]
           }

--- a/src/routes.jsx
+++ b/src/routes.jsx
@@ -103,12 +103,12 @@ const router = createBrowserRouter([
               {
                 path: "step2",
                 element: <PrivateRoute element={<SelectSeatInterpark />} />,
-                label: ""
+                label: "좌석 선택"
               },
               {
                 path: "step3-1",
                 element: <PrivateRoute element={<SelectPriceInterpark />} />,
-                label: "날짜 및 회차 선택"
+                label: "가격 및 할인 선택"
               },
               {
                 path: "step4-1",

--- a/src/store/atom.js
+++ b/src/store/atom.js
@@ -6,17 +6,9 @@ import getRandomInt from "../util/getRandomInt";
 const storage = createJSONStorage(() => sessionStorage);
 // 초 단위 타이머 상태
 export const secondCountAtom = atomWithStorage("second", 0, storage);
-// export const readSecondCount = atom((get) => get(secondCountAtom));
-// export const writeSecondCount = atom(null, (get, set, update) =>
-//   set(secondCountAtom, update(get(secondCountAtom)))
-// );
 
 // 분 단위 타이머 상태
 export const minuteCountAtom = atomWithStorage("minute", 0, storage);
-// export const readMinuteCount = atom((get) => get(minuteCountAtom));
-// export const writeMinuteCount = atom(null, (get, set, update) =>
-//   set(minuteCountAtom, update(get(minuteCountAtom)))
-// );
 // const someAtom = atomWithStorage('some-key', someInitialValue, storage)
 
 //난이도 상태 (low, middle, high)

--- a/src/util/resetAtom.js
+++ b/src/util/resetAtom.js
@@ -7,9 +7,9 @@ const resetAtom = () => {
   sessionStorage.removeItem("seatCount");
   sessionStorage.removeItem("seatInfo");
   sessionStorage.removeItem("posterId");
-  sessionStorage.removeItem("minute");
   sessionStorage.removeItem("level");
   sessionStorage.removeItem("stepTextNumber");
+  sessionStorage.removeItem("minute");
   sessionStorage.removeItem("helpTextNumber");
 };
 


### PR DESCRIPTION
## 📝작업 내용

### ✅ 인터파크 결제창 page 생성
* 실전모드는 연습모드보다 사용자에게 더 복잡한 정보를 제공하는 거에 초점을 맞춤 (현금영수증 정보, 포인트 정보에 대한 화면만 추가함, 여러 사이트에서 쓸 수 있을지도)

### ✅ 연습모드 기준 step3, step4 검사 로직 분리
* 기존에는 MyBookingInfo 컴포넌트에 검사 로직이 포함돼 있었음
* 연습모드에서 쓰던 방식대로 그대로 쓰면 분리가 필요가 없지만, 결제창 이후까지도 MyBookingInfo를 사용해야 됨
* 결제창에서는 이전버튼/다음버튼에 사용해야 할 로직이 다름
* MyBookingInfo의 버튼 컴포넌트가 수행해야 할 로직을 if문을 중첩해서 쓰기엔 이미 너무 복잡함

**📍결론 : 검사 로직과 버튼을 분리해서 원하는 로직을 원하는 버튼에 전달하여 사용할 수 있도록 수정, 재사용성을 높임**


### ✅ 연습모드 기준 step3 버튼 분리
* 기존 버튼은 MyBookingInfo 컴포넌트 내에 존재
* 이전버튼 다음버튼은 화면 및 구현 방식에 따라 다양한 검사 로직이 존재할 것이고, 여러 구동 방식이 필요할 것
* 버튼을 따로 분리하여 필요한 로직을 받아 사용하는 PrevNextButton 컴포넘트 생성
: prevOnClick,  nextOnClick props를 받아 검사로직을 수행하거나 특정 화면으로 navigate할 수 있도록 함
* 버튼을 포함하여 테두리를 그린 컴포넌트를 쉽게 생성하기 위해 MyBookingInfoContainer 스타일 컴포넌트를 따로 빼둠
* 이전/ 다음버튼을 다시 사용하고 싶다면 MyBookingInfoContainer 컴포넌트를 갖고와서 MyBookingInfo와 PrevNextButton 컴포넌트를 감싸주면 됨
<img src='https://github.com/user-attachments/assets/1eef6bad-ad31-4650-88e0-924503fc4f3b' width='500px'/>

**📍컴포넌트는 재사용성이 높기에 웬만해서 페이지 로직에 대한 부분은 넣으면 안된다는 걸 깨달았음**

## 💬리뷰 요구사항
* 인터파크는 연습모드와 step 번호가 다름, 인터파크의 라우터를 다시 작성해야 할 듯
* 프로그래스바의 텍스트는  props로 받을 컨텐츠를 바꾸는 방식으로 리팩토링 필요