### PR TITLE
Feat: 예매 과정 진행 중 헤더로 다른 페이지 이동 시 gotoModal 창 생성

### DIFF
--- a/src/components/header/nav/Nav.jsx
+++ b/src/components/header/nav/Nav.jsx
@@ -110,7 +110,6 @@ const Nav = () => {
               $ishovered={ishovered}
               $isactive={hovereditem === "실전모드"}
               onMouseEnter={() => handleHoveredItemEnter("실전모드")}
-              onClick={() => nav("/record")}
             >
               실전 모드
             </NavContent>
@@ -118,6 +117,7 @@ const Nav = () => {
               $ishovered={ishovered}
               $isactive={hovereditem === null}
               onMouseEnter={() => handleHoveredItemEnter(null)}
+              onClick={() => nav("/record")}
             >
               기록 보기
             </NavContent>

--- a/src/components/header/nav/Nav.jsx
+++ b/src/components/header/nav/Nav.jsx
@@ -1,8 +1,12 @@
-import React from "react";
+import React, { useState } from "react";
 import styled, { css } from "styled-components"; // css 함수 import 추가
 import SubNav from "./subNav/SubNav";
 import useHover from "../../../hooks/useHover";
-import { useNavigate } from "react-router-dom";
+import { useLocation, useNavigate } from "react-router-dom";
+import GoToLocationModalCont from "../../modal/GoToMainModalCont";
+import Modal from "../../modal/Modal";
+import { useSetAtom } from "jotai";
+import { timerControlAtom } from "../../../store/atom";
 
 /*네비게이터 전체 */
 const NavBorderBottom = styled.div`
@@ -88,9 +92,34 @@ const Nav = () => {
     handleMouseLeave,
     handleMouseEnter
   } = useHover();
+  //모달창 제어
+  const [isConfirm, setIsConfirm] = useState("");
+  const setTimerControl = useSetAtom(timerControlAtom);
+  const path = useLocation().pathname;
   const nav = useNavigate();
+
+  const handleClick = () => {
+    setTimerControl(false);
+    if (path.includes("step") && !path.includes("step0")) {
+      setIsConfirm(true);
+      return;
+    }
+    nav("/record");
+  };
+
   return (
     <NavBorderBottom>
+      {isConfirm && (
+        <Modal
+          buttonShow={false}
+          contents={
+            <GoToLocationModalCont
+              levelTheme="/record"
+              setIsConfirm={setIsConfirm}
+            />
+          }
+        />
+      )}
       <NavWrap>
         {/*hover 시 서브네비게이터가 나오도록 허용할 네비게이터 구간 */}
         <NavHoverSection
@@ -117,7 +146,7 @@ const Nav = () => {
               $ishovered={ishovered}
               $isactive={hovereditem === null}
               onMouseEnter={() => handleHoveredItemEnter(null)}
-              onClick={() => nav("/record")}
+              onClick={handleClick}
             >
               기록 보기
             </NavContent>

--- a/src/components/header/nav/subNav/SubNav.jsx
+++ b/src/components/header/nav/subNav/SubNav.jsx
@@ -1,5 +1,5 @@
 import styled from "styled-components";
-import { useNavigate } from "react-router-dom";
+import { useLocation, useNavigate } from "react-router-dom";
 import {
   levelAtom,
   themeSiteAtom,
@@ -8,6 +8,9 @@ import {
 } from "../../../../store/atom";
 import { useAtomValue, useSetAtom } from "jotai";
 import resetAtom from "../../../../util/resetAtom";
+import { useState } from "react";
+import Modal from "../../../modal/Modal";
+import GoToMainModalCont from "../../../modal/GoToMainModalCont";
 const SubNavBgc = styled.div`
   width: 100vw;
   height: 45px;
@@ -53,11 +56,19 @@ const SubNav = ({ hovereditem }) => {
   //접근 시 에러 발생
   const userName = useAtomValue(userNameAtom);
   const setUserNameError = useSetAtom(userNameErrorAtom);
+  //현재 페이지
+  const path = useLocation().pathname;
+  //헤더를 이용해 메인화면으로 나갈 경우
+  const [isConfirm, setIsConfirm] = useState(false);
 
   const handleNavigate = (location) => {
     //입력된 userName이 없을 경우
     if (!userName) {
       setUserNameError(true);
+      return;
+    }
+    if (path.includes("step") && !path.includes("step0")) {
+      setIsConfirm(true);
       return;
     }
     if (location === "low" || location === "middle" || location === "high") {
@@ -73,6 +84,12 @@ const SubNav = ({ hovereditem }) => {
 
   return (
     <>
+      {isConfirm && (
+        <Modal
+          buttonShow={false}
+          contents={<GoToMainModalCont setIsConfirm={setIsConfirm} />}
+        />
+      )}
       {hovereditem === "연습모드" && (
         <SubNavBgc>
           <SubNavWrap>

--- a/src/components/header/nav/subNav/SubNav.jsx
+++ b/src/components/header/nav/subNav/SubNav.jsx
@@ -10,7 +10,8 @@ import { useAtomValue, useSetAtom } from "jotai";
 import resetAtom from "../../../../util/resetAtom";
 import { useState } from "react";
 import Modal from "../../../modal/Modal";
-import GoToMainModalCont from "../../../modal/GoToMainModalCont";
+import GoToLocationModalCont from "../../../modal/GoToMainModalCont";
+
 const SubNavBgc = styled.div`
   width: 100vw;
   height: 45px;
@@ -60,18 +61,33 @@ const SubNav = ({ hovereditem }) => {
   const path = useLocation().pathname;
   //헤더를 이용해 메인화면으로 나갈 경우
   const [isConfirm, setIsConfirm] = useState(false);
+  const [levelTheme, setLevelTheme] = useState("");
+  const [navLocation, setNavLocation] = useState("");
+
+  //어디로 이동할 것인지 필터링
+  const practiceMode = ["low", "middle", "high"];
 
   const handleNavigate = (location) => {
-    //입력된 userName이 없을 경우
+    //입력된 userName이 없을 경우 userName 입력 받기
     if (!userName) {
       setUserNameError(true);
       return;
     }
+    //예매 과정 진행 중일 경우 모달창 켜서 제어
+    //reset은 모달창에서 진행
     if (path.includes("step") && !path.includes("step0")) {
       setIsConfirm(true);
-      return;
+      if (practiceMode.includes(location)) {
+        setNavLocation("progress/step0");
+        setLevelTheme(location);
+        return;
+      } else {
+        setNavLocation(`challenge/${location}/step0`);
+        setLevelTheme(location);
+        return;
+      }
     }
-    if (location === "low" || location === "middle" || location === "high") {
+    if (practiceMode.includes(location)) {
       resetAtom();
       setLevel(location); // 레벨 설정
       nav("/progress/step0"); // 연습모드 step0로 이동
@@ -87,7 +103,13 @@ const SubNav = ({ hovereditem }) => {
       {isConfirm && (
         <Modal
           buttonShow={false}
-          contents={<GoToMainModalCont setIsConfirm={setIsConfirm} />}
+          contents={
+            <GoToLocationModalCont
+              navLocation={navLocation}
+              setIsConfirm={setIsConfirm}
+              levelTheme={levelTheme}
+            />
+          }
         />
       )}
       {hovereditem === "연습모드" && (

--- a/src/components/header/nav/subNav/SubNav.jsx
+++ b/src/components/header/nav/subNav/SubNav.jsx
@@ -63,7 +63,6 @@ const SubNav = ({ hovereditem }) => {
   //헤더를 이용해 메인화면으로 나갈 경우
   const [isConfirm, setIsConfirm] = useState(false);
   const [levelTheme, setLevelTheme] = useState("");
-  const [navLocation, setNavLocation] = useState("");
   //어디로 이동할 것인지 필터링
   const practiceMode = ["low", "middle", "high"];
   //모달창 타이머 제어
@@ -81,11 +80,9 @@ const SubNav = ({ hovereditem }) => {
       setIsConfirm(true);
       setTimerControl(true);
       if (practiceMode.includes(location)) {
-        setNavLocation("progress/step0");
         setLevelTheme(location);
         return;
       } else {
-        setNavLocation(`challenge/${location}/step0`);
         setLevelTheme(location);
         return;
       }
@@ -108,7 +105,6 @@ const SubNav = ({ hovereditem }) => {
           buttonShow={false}
           contents={
             <GoToLocationModalCont
-              navLocation={navLocation}
               setIsConfirm={setIsConfirm}
               levelTheme={levelTheme}
             />

--- a/src/components/header/nav/subNav/SubNav.jsx
+++ b/src/components/header/nav/subNav/SubNav.jsx
@@ -3,6 +3,7 @@ import { useLocation, useNavigate } from "react-router-dom";
 import {
   levelAtom,
   themeSiteAtom,
+  timerControlAtom,
   userNameAtom,
   userNameErrorAtom
 } from "../../../../store/atom";
@@ -63,9 +64,10 @@ const SubNav = ({ hovereditem }) => {
   const [isConfirm, setIsConfirm] = useState(false);
   const [levelTheme, setLevelTheme] = useState("");
   const [navLocation, setNavLocation] = useState("");
-
   //어디로 이동할 것인지 필터링
   const practiceMode = ["low", "middle", "high"];
+  //모달창 타이머 제어
+  const setTimerControl = useSetAtom(timerControlAtom);
 
   const handleNavigate = (location) => {
     //입력된 userName이 없을 경우 userName 입력 받기
@@ -77,6 +79,7 @@ const SubNav = ({ hovereditem }) => {
     //reset은 모달창에서 진행
     if (path.includes("step") && !path.includes("step0")) {
       setIsConfirm(true);
+      setTimerControl(true);
       if (practiceMode.includes(location)) {
         setNavLocation("progress/step0");
         setLevelTheme(location);

--- a/src/components/modal/GoToMainModalCont.jsx
+++ b/src/components/modal/GoToMainModalCont.jsx
@@ -26,7 +26,7 @@ const ButtonWrap = styled.div`
   display: flex;
 `;
 
-const GoToLocationModalCont = ({ setIsConfirm, levelTheme = null }) => {
+const GoToLocationModalCont = ({ setIsConfirm, levelTheme = "/" }) => {
   const navigate = useNavigate();
   //타이머 제어
   const setTimerControl = useSetAtom(timerControlAtom);
@@ -55,7 +55,7 @@ const GoToLocationModalCont = ({ setIsConfirm, levelTheme = null }) => {
         navigate(`challenge/${levelTheme}/step0`);
         return;
       }
-      navigate("/");
+      navigate(levelTheme);
       return;
     }
     //취소를 누를 경우

--- a/src/components/modal/GoToMainModalCont.jsx
+++ b/src/components/modal/GoToMainModalCont.jsx
@@ -25,11 +25,8 @@ const Info = styled.span`
 const ButtonWrap = styled.div`
   display: flex;
 `;
-const GoToLocationModalCont = ({
-  setIsConfirm,
-  navLocation = "/",
-  levelTheme = null
-}) => {
+
+const GoToLocationModalCont = ({ setIsConfirm, levelTheme = null }) => {
   const navigate = useNavigate();
   //타이머 제어
   const setTimerControl = useSetAtom(timerControlAtom);
@@ -40,19 +37,25 @@ const GoToLocationModalCont = ({
   const challengeMode = ["interpark", "ticketlink", "yes24", "melonticket"];
 
   const handleClick = (confirmNavigate) => {
-    //확인을 누를 경우
+    //확인을 누를 경우 - 기본 설정 사항
+    setTimerControl(() => false);
+    setIsConfirm(() => false);
+    resetAtom();
     if (confirmNavigate) {
       //levelTheme이 존재 : 헤더를 통한 이동
       if (levelTheme && practiceMode.includes(levelTheme)) {
+        //연습모드
         setLevel(levelTheme);
+        navigate("progress/step0");
+        return;
       }
       if (levelTheme && challengeMode.includes(levelTheme)) {
+        //실전모드
         setTheme(levelTheme);
+        navigate(`challenge/${levelTheme}/step0`);
+        return;
       }
-      setTimerControl(() => false);
-      setIsConfirm(() => false);
-      resetAtom();
-      navigate(navLocation);
+      navigate("/");
       return;
     }
     //취소를 누를 경우

--- a/src/components/modal/GoToMainModalCont.jsx
+++ b/src/components/modal/GoToMainModalCont.jsx
@@ -2,7 +2,7 @@ import styled from "styled-components";
 import Button from "../button/Button";
 import { useNavigate } from "react-router-dom";
 import { useSetAtom } from "jotai";
-import { timerControlAtom } from "../../store/atom";
+import { levelAtom, themeSiteAtom, timerControlAtom } from "../../store/atom";
 import resetAtom from "../../util/resetAtom";
 
 const Container = styled.div`
@@ -25,17 +25,34 @@ const Info = styled.span`
 const ButtonWrap = styled.div`
   display: flex;
 `;
-const GoToMainModalCont = ({ setIsConfirm }) => {
+const GoToLocationModalCont = ({
+  setIsConfirm,
+  navLocation = "/",
+  levelTheme = null
+}) => {
   const navigate = useNavigate();
   //타이머 제어
   const setTimerControl = useSetAtom(timerControlAtom);
+  //level 및 theme 제어
+  const setLevel = useSetAtom(levelAtom);
+  const setTheme = useSetAtom(themeSiteAtom);
+  const practiceMode = ["low", "middle", "high"];
+  const challengeMode = ["interpark", "ticketlink", "yes24", "melonticket"];
+
   const handleClick = (confirmNavigate) => {
     //확인을 누를 경우
     if (confirmNavigate) {
+      //levelTheme이 존재 : 헤더를 통한 이동
+      if (levelTheme && practiceMode.includes(levelTheme)) {
+        setLevel(levelTheme);
+      }
+      if (levelTheme && challengeMode.includes(levelTheme)) {
+        setTheme(levelTheme);
+      }
       setTimerControl(() => false);
       setIsConfirm(() => false);
       resetAtom();
-      navigate("/");
+      navigate(navLocation);
       return;
     }
     //취소를 누를 경우
@@ -45,7 +62,7 @@ const GoToMainModalCont = ({ setIsConfirm }) => {
   return (
     <Container>
       <InfoContainer>
-        <Info>메인화면으로 이동하시겠습니까?</Info>
+        <Info>이동하시겠습니까?</Info>
         <Info $highlight={true}>진행상황은 저장되지 않습니다</Info>
       </InfoContainer>
       <ButtonWrap>
@@ -60,4 +77,4 @@ const GoToMainModalCont = ({ setIsConfirm }) => {
   );
 };
 
-export default GoToMainModalCont;
+export default GoToLocationModalCont;

--- a/src/pages/main/Main.jsx
+++ b/src/pages/main/Main.jsx
@@ -13,7 +13,6 @@ import { useNavigate } from "react-router-dom";
 import MainImage from "../../assests/images/main.png";
 import { InputField } from "../../components/input/InputStyle";
 import ErrorTooltip from "../../components/tooltip/ErrorTooltip";
-import GoToMainModalCont from "../../components/modal/GoToMainModalCont";
 
 const MainContainer = styled.div`
   display: flex;


### PR DESCRIPTION
## 📝작업 내용

### 예매 과정 진행 중에 헤더로 다른 페이지 이동 시에 안내 문구 및 선택 모달창 생성
<img src='https://github.com/user-attachments/assets/f00ba77a-2ce9-4c9c-8c8e-75b69060df0a' width="500px"/>

### 모달창 생성 시 타이머 제어 설정
### 모달창 이동 시 themeSite 및 
* 기존에는 헤더를 클릭 시 곧바로 이동했기 때문에 헤더에서 themeSite 및 level 제어
* 지금은 모달창의 확인버튼을 거쳐 이동해야 하기 때문에 확인을 누를 시 themeSite 또는 level이 설정되고 화면이 이동될 수 있도록 구성
* gotoMain 모달창을 gotoLocationModal 로 변경
-> nav 컴포넌트에서 levelTheme 을 받아 해당 

## 💬리뷰 요구사항
* themeSite 제어나 level이 변경되는 부분에서 오류가 나진 않는지 확인 필요
