### PR TITLE
Fix: 좌석 컴포넌트의 배치 및 atom 초기화 버그 수정

### DIFF
--- a/src/components/SeatCount.jsx
+++ b/src/components/SeatCount.jsx
@@ -59,7 +59,9 @@ const SeatCount = () => {
   const handleSeatCountChange = (event) => {
     setSeatCount(Number(event.target.value));
   };
-
+  useEffect(() => {
+    setSeatCount(0);
+  }, []);
   useEffect(() => {
     if (seatCount === 0 && level === "low") {
       setFocus(true);

--- a/src/components/card/settings/vertical/VerticalFront.jsx
+++ b/src/components/card/settings/vertical/VerticalFront.jsx
@@ -5,7 +5,7 @@ import { CardWrap, Number } from "../CardStyles";
 const VerticalFront = () => {
   return (
     <CardWrap>
-      {/*카드 앞부분 */}s
+      {/*카드 앞부분 */}
       <CardBFront />
     </CardWrap>
   );

--- a/src/components/seatChart/SeatChart1.jsx
+++ b/src/components/seatChart/SeatChart1.jsx
@@ -9,6 +9,12 @@ const SectionName = styled.div`
   font-family: "pretendardB";
   margin: 20px;
 `;
+const SeatChartContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+`;
 
 const SeatChart = () => {
   const allowedSection = useAtomValue(allowedSectionAtom);
@@ -26,10 +32,10 @@ const SeatChart = () => {
   useFakeAllowedSeat(0, 9, 9);
 
   return (
-    <>
+    <SeatChartContainer>
       <SectionName>{allowedSection}구역</SectionName>
       <SeatGrid rows={10} columns={10} gridIndex={0} />
-    </>
+    </SeatChartContainer>
   );
 };
 

--- a/src/components/seatInfo/SeatInfo.jsx
+++ b/src/components/seatInfo/SeatInfo.jsx
@@ -2,6 +2,7 @@ import Button from "../button/Button";
 import { useAtomValue, useAtom } from "jotai";
 import {
   isSeatSelectedAtom,
+  isSectionSelectedAtom,
   allowedSeatAtom,
   levelAtom,
   postersAtom,
@@ -30,6 +31,7 @@ import { useLocation } from "react-router-dom";
 
 const SeatInfo = () => {
   const isSeatSelected = useAtomValue(isSeatSelectedAtom);
+  const isSectionSelected = useAtomValue(isSectionSelectedAtom);
   const allowedSeat = useAtomValue(allowedSeatAtom);
   const level = useAtomValue(levelAtom);
   const posters = useAtomValue(postersAtom);
@@ -61,18 +63,21 @@ const SeatInfo = () => {
   const nav = useNavigate();
 
   const handleButtonClick = () => {
-    if (themeSite === "practice") {
-      nav("../step3-1");
-      return;
-    }
     if (isSeatSelected) {
       if (path.includes("challenge")) {
         nav("../step3/step4");
-      } else {
-        nav("../step3-1");
+        return;
       }
-    } else {
+      nav("../step3-1");
+    }
+
+    if (!isSectionSelected) {
+      alert("구역을 선택해주세요.");
+      return;
+    }
+    if (!isSeatSelected) {
       alert("좌석을 선택해주세요.");
+      return;
     }
   };
 

--- a/src/hooks/useBookingValidate.js
+++ b/src/hooks/useBookingValidate.js
@@ -20,7 +20,7 @@ export const useBookingValidate = (
     // 연습모드
     // 좌석 매수가 0일 경우 경고창 출력
     if (seatCount === 0) {
-      alert("좌석을 선택해주세요.");
+      alert("좌석매수를 선택해주세요.");
       return;
     }
     addStage(2);

--- a/src/pages/ProgressContents.jsx
+++ b/src/pages/ProgressContents.jsx
@@ -80,14 +80,14 @@ const ProgressContents = ({ text, practiceMode, challengeMode }) => {
   // 현재 경로가 step0인지 확인하기 위한 변수 정의
   const isStep0Path = location.pathname.includes("step0");
 
-  // // 시간이 초과되었을 때 타임아웃 모달 열리도록 설정
-  // useEffect(() => {
-  //   // 남은 시간 0 이하일 때만 모달이 열리도록 설정
-  //   if (timeSpent <= 0 && !isStep0Path) {
-  //     setIsTimeoutModalContentsOpen(true);
-  //     setTimerControl(false); // 타이머 정지
-  //   }
-  // }, [timeSpent, setTimerControl]);
+  // 시간이 초과되었을 때 타임아웃 모달 열리도록 설정
+  useEffect(() => {
+    // 남은 시간 0 이하일 때만 모달이 열리도록 설정
+    if (timeSpent <= 0 && !isStep0Path) {
+      setIsTimeoutModalContentsOpen(true);
+      setTimerControl(false); // 타이머 정지
+    }
+  }, [timeSpent, setTimerControl]);
 
   const handleModalOpen = () => {
     setIsModalOpen(true);

--- a/src/pages/challengeMode/selectSeat/SelectSeatChallangeMode.jsx
+++ b/src/pages/challengeMode/selectSeat/SelectSeatChallangeMode.jsx
@@ -3,9 +3,10 @@ import styled from "styled-components";
 import SecureModalContents from "../../../components/modal/modalContents/SecureModalContents";
 import SeatChart from "../../../components/seatChart/SeatChart1";
 import SeatSection from "../../../components/seatSection/SeatSection";
-import { useAtomValue, useSetAtom } from "jotai";
+import { useAtomValue, useSetAtom, useAtom } from "jotai";
 import {
   isSectionSelectedAtom,
+  isSeatSelectedAtom,
   progressAtom,
   themeSiteAtom
 } from "../../../store/atom";
@@ -27,17 +28,23 @@ const SeatInfoContainer = styled.div`
 
 const TooltipText = styled.div`
   width: 380px;
+  font-size: 16px;
   font-family: PretendardM;
 `;
 
 const SelectSeatChallengeMode = () => {
   const [isModalOpen, setIsModalOpen] = useState(true);
-  const isSectionSelected = useAtomValue(isSectionSelectedAtom);
+  const [isSectionSelected, setIsSectionSelected] = useAtom(
+    isSectionSelectedAtom
+  );
+  const [isSeatSelected, setIsSeatSelected] = useAtom(isSeatSelectedAtom);
   const setProgress = useSetAtom(progressAtom);
   const themeSite = useAtomValue(themeSiteAtom);
 
   useEffect(() => {
     setProgress(2);
+    setIsSectionSelected(false);
+    setIsSeatSelected(false);
   }, []);
 
   const closeModal = () => {


### PR DESCRIPTION
# 📝작업 내용
- 좌석/구역 미선택시 alret창 나타나게 수정
- seatChart1 컴포넌트에 flex적용
- SelectSeatChallenge 초기화시 atom 초기화
- step3/step4 새로고침시 seatcountAtom 초기화, 
- useValidatehook에서 "좌석을 선택해주세요"-> "좌석 매수를 선택해주세요"로 고침
- card VerticalFront에서 "s" 문자 삭제

## 스크린샷 (선택)

## 💬리뷰 요구사항

